### PR TITLE
Change the type of struct member from primitive-type to pointer-of-primitive-type

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/go/GoNames.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/GoNames.java
@@ -161,7 +161,7 @@ public class GoNames {
         return buildClassName(type.getName(), null, TYPES_PACKAGE);
     }
 
-    public static Boolean isPrimitiveTypeCanAsPointer(Type type) {
+    public static Boolean isGoPrimitiveType(Type type) {
         if (type instanceof PrimitiveType) {
             if (type == type.getModel().getBooleanType() ||
                 type == type.getModel().getIntegerType() ||

--- a/generator/src/main/java/org/ovirt/sdk/go/ServicesGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/ServicesGenerator.java
@@ -828,8 +828,11 @@ public class ServicesGenerator implements GoGenerator {
     private void generateSetActionAttribute(Parameter parameter) {
         String memberName = goNames.getMemberStyleName(parameter.getName());
         String parameterName = goNames.getParameterStyleName(parameter.getName());
-
-        buffer.addLine("%1$s: %2$s,", memberName, parameterName);
+        String varTypeSuffix = "";
+        if (GoNames.isPrimitiveTypeCanAsPointer(parameter.getType())) {
+            varTypeSuffix = "&";
+        }
+        buffer.addLine("%1$s: %2$s%3$s,", memberName, varTypeSuffix, parameterName);
     }
 
 }

--- a/generator/src/main/java/org/ovirt/sdk/go/ServicesGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/ServicesGenerator.java
@@ -829,7 +829,7 @@ public class ServicesGenerator implements GoGenerator {
         String memberName = goNames.getMemberStyleName(parameter.getName());
         String parameterName = goNames.getParameterStyleName(parameter.getName());
         String varTypeSuffix = "";
-        if (GoNames.isPrimitiveTypeCanAsPointer(parameter.getType())) {
+        if (GoNames.isGoPrimitiveType(parameter.getType())) {
             varTypeSuffix = "&";
         }
         buffer.addLine("%1$s: %2$s%3$s,", memberName, varTypeSuffix, parameterName);

--- a/generator/src/main/java/org/ovirt/sdk/go/TypesGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/TypesGenerator.java
@@ -178,7 +178,7 @@ public class TypesGenerator implements GoGenerator {
     }
 
     private void generateMemberFormalParameter(StructMember member) {
-        GoTypeReference goTypeReference = goNames.getTypeReference(member.getType());
+        GoTypeReference goTypeReference = goNames.getTypeReferenceAsStructMember(member.getType());
         buffer.addImports(goTypeReference.getImports());
         buffer.addLine(
             "%1$s    %2$s   `xml:\"%3$s\"` ",

--- a/sdk/ovirtsdk4/service.go
+++ b/sdk/ovirtsdk4/service.go
@@ -30,7 +30,8 @@ type BaseService struct {
 
 func checkFault(response *OvResponse) error {
 	if len(response.Body) == 0 {
-		return &Fault{Detail: fmt.Sprintf("HTTP response code is %d", response.Code)}
+		detailStr := fmt.Sprintf("HTTP response code is %d", response.Code)
+		return &Fault{Detail: &detailStr}
 	}
 	// xml unmarshal into Fault struct
 	var faultVar Fault

--- a/sdk/ovirtsdk4/services.go
+++ b/sdk/ovirtsdk4/services.go
@@ -2382,7 +2382,7 @@ func (op *AttachedStorageDomainService) Activate(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -2416,7 +2416,7 @@ func (op *AttachedStorageDomainService) Deactivate(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -3314,7 +3314,7 @@ func (op *ClusterService) ResetEmulatedMachine(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -3781,7 +3781,7 @@ func (op *CopyableService) Copy(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -6114,7 +6114,7 @@ func (op *EventsService) Undelete(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -6762,7 +6762,7 @@ func (op *ExternalProviderService) TestConnectivity(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -7542,7 +7542,7 @@ func (op *GlusterBricksService) Activate(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:  async,
+		Async:  &async,
 		Bricks: bricks,
 	}
 
@@ -7696,7 +7696,7 @@ func (op *GlusterBricksService) Migrate(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:  async,
+		Async:  &async,
 		Bricks: bricks,
 	}
 
@@ -7787,7 +7787,7 @@ func (op *GlusterBricksService) StopMigrate(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:  async,
+		Async:  &async,
 		Bricks: bricks,
 	}
 
@@ -7850,7 +7850,7 @@ func (op *GlusterHookService) Disable(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -7874,7 +7874,7 @@ func (op *GlusterHookService) Enable(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -7952,9 +7952,9 @@ func (op *GlusterHookService) Resolve(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:          async,
+		Async:          &async,
 		Host:           host,
-		ResolutionType: resolutionType,
+		ResolutionType: &resolutionType,
 	}
 
 	// Send the request and wait for the response:
@@ -9322,10 +9322,10 @@ func (op *ImageService) Import(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:            async,
+		Async:            &async,
 		Cluster:          cluster,
 		Disk:             disk,
-		ImportAsTemplate: importAsTemplate,
+		ImportAsTemplate: &importAsTemplate,
 		StorageDomain:    storageDomain,
 		Template:         template,
 	}
@@ -11018,7 +11018,7 @@ func (op *JobService) Clear(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -11059,9 +11059,9 @@ func (op *JobService) End(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:     async,
-		Force:     force,
-		Succeeded: succeeded,
+		Async:     &async,
+		Force:     &force,
+		Succeeded: &succeeded,
 	}
 
 	// Send the request and wait for the response:
@@ -11792,7 +11792,7 @@ func (op *MoveableService) Move(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -13042,10 +13042,10 @@ func (op *OpenstackImageService) Import(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:            async,
+		Async:            &async,
 		Cluster:          cluster,
 		Disk:             disk,
-		ImportAsTemplate: importAsTemplate,
+		ImportAsTemplate: &importAsTemplate,
 		StorageDomain:    storageDomain,
 		Template:         template,
 	}
@@ -13162,7 +13162,7 @@ func (op *OpenstackImageProviderService) TestConnectivity(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -13457,7 +13457,7 @@ func (op *OpenstackNetworkService) Import(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:      async,
+		Async:      &async,
 		DataCenter: dataCenter,
 	}
 
@@ -13598,7 +13598,7 @@ func (op *OpenstackNetworkProviderService) TestConnectivity(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -14310,7 +14310,7 @@ func (op *OpenstackVolumeProviderService) TestConnectivity(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -16647,9 +16647,9 @@ func (op *SnapshotService) Restore(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:         async,
+		Async:         &async,
 		Disks:         disks,
-		RestoreMemory: restoreMemory,
+		RestoreMemory: &restoreMemory,
 	}
 
 	// Send the request and wait for the response:
@@ -17591,9 +17591,9 @@ func (op *StepService) End(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:     async,
-		Force:     force,
-		Succeeded: succeeded,
+		Async:     &async,
+		Force:     &force,
+		Succeeded: &succeeded,
 	}
 
 	// Send the request and wait for the response:
@@ -18001,7 +18001,7 @@ func (op *StorageDomainService) IsAttached(
 	error) {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 		Host:  host,
 	}
 
@@ -18089,7 +18089,7 @@ func (op *StorageDomainService) RefreshLuns(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:        async,
+		Async:        &async,
 		LogicalUnits: logicalUnits,
 	}
 
@@ -18228,7 +18228,7 @@ func (op *StorageDomainService) UpdateOvfStore(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -18617,8 +18617,8 @@ func (op *StorageDomainDiskService) Move(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:         async,
-		Filter:        filter,
+		Async:         &async,
+		Filter:        &filter,
 		StorageDomain: storageDomain,
 	}
 
@@ -19092,10 +19092,10 @@ func (op *StorageDomainTemplateService) Import(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:         async,
-		Clone:         clone,
+		Async:         &async,
+		Clone:         &clone,
 		Cluster:       cluster,
-		Exclusive:     exclusive,
+		Exclusive:     &exclusive,
 		StorageDomain: storageDomain,
 		Template:      template,
 		Vm:            vm,
@@ -19129,11 +19129,11 @@ func (op *StorageDomainTemplateService) Register(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		AllowPartialImport: allowPartialImport,
-		Async:              async,
-		Clone:              clone,
+		AllowPartialImport: &allowPartialImport,
+		Async:              &async,
+		Clone:              &clone,
 		Cluster:            cluster,
-		Exclusive:          exclusive,
+		Exclusive:          &exclusive,
 		Template:           template,
 	}
 
@@ -19381,10 +19381,10 @@ func (op *StorageDomainVmService) Import(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:             async,
-		Clone:             clone,
+		Async:             &async,
+		Clone:             &clone,
 		Cluster:           cluster,
-		CollapseSnapshots: collapseSnapshots,
+		CollapseSnapshots: &collapseSnapshots,
 		StorageDomain:     storageDomain,
 		Vm:                vm,
 	}
@@ -19424,11 +19424,11 @@ func (op *StorageDomainVmService) Register(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		AllowPartialImport:  allowPartialImport,
-		Async:               async,
-		Clone:               clone,
+		AllowPartialImport:  &allowPartialImport,
+		Async:               &async,
+		Clone:               &clone,
 		Cluster:             cluster,
-		ReassignBadMacs:     reassignBadMacs,
+		ReassignBadMacs:     &reassignBadMacs,
 		Vm:                  vm,
 		VnicProfileMappings: vnicProfileMappings,
 	}
@@ -20513,7 +20513,7 @@ func (op *SystemService) ReloadConfigurations(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -21512,7 +21512,7 @@ func (op *TemplateService) Export(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Exclusive:     exclusive,
+		Exclusive:     &exclusive,
 		StorageDomain: storageDomain,
 	}
 
@@ -21914,8 +21914,8 @@ func (op *TemplateDiskService) Copy(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:  async,
-		Filter: filter,
+		Async:  &async,
+		Filter: &filter,
 	}
 
 	// Send the request and wait for the response:
@@ -21939,8 +21939,8 @@ func (op *TemplateDiskService) Export(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:  async,
-		Filter: filter,
+		Async:  &async,
+		Filter: &filter,
 	}
 
 	// Send the request and wait for the response:
@@ -23615,7 +23615,7 @@ func (op *VmService) CancelMigration(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -23638,7 +23638,7 @@ func (op *VmService) Clone(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 		Vm:    vm,
 	}
 
@@ -23661,7 +23661,7 @@ func (op *VmService) CommitSnapshot(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -23694,7 +23694,7 @@ func (op *VmService) Detach(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -23740,9 +23740,9 @@ func (op *VmService) Export(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:            async,
-		DiscardSnapshots: discardSnapshots,
-		Exclusive:        exclusive,
+		Async:            &async,
+		DiscardSnapshots: &discardSnapshots,
+		Exclusive:        &exclusive,
 		StorageDomain:    storageDomain,
 	}
 
@@ -23778,7 +23778,7 @@ func (op *VmService) FreezeFilesystems(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -23877,7 +23877,7 @@ func (op *VmService) Logon(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -23914,8 +23914,8 @@ func (op *VmService) Maintenance(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:              async,
-		MaintenanceEnabled: maintenanceEnabled,
+		Async:              &async,
+		MaintenanceEnabled: &maintenanceEnabled,
 	}
 
 	// Send the request and wait for the response:
@@ -23959,9 +23959,9 @@ func (op *VmService) Migrate(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:   async,
+		Async:   &async,
 		Cluster: cluster,
-		Force:   force,
+		Force:   &force,
 		Host:    host,
 	}
 
@@ -23988,9 +23988,9 @@ func (op *VmService) PreviewSnapshot(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:         async,
+		Async:         &async,
 		Disks:         disks,
-		RestoreMemory: restoreMemory,
+		RestoreMemory: &restoreMemory,
 		Snapshot:      snapshot,
 		Vm:            vm,
 	}
@@ -24025,7 +24025,7 @@ func (op *VmService) Reboot(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -24084,7 +24084,7 @@ func (op *VmService) ReorderMacAddresses(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -24117,7 +24117,7 @@ func (op *VmService) Shutdown(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -24181,11 +24181,11 @@ func (op *VmService) Start(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:        async,
-		Filter:       filter,
-		Pause:        pause,
-		UseCloudInit: useCloudInit,
-		UseSysprep:   useSysprep,
+		Async:        &async,
+		Filter:       &filter,
+		Pause:        &pause,
+		UseCloudInit: &useCloudInit,
+		UseSysprep:   &useSysprep,
 		Vm:           vm,
 	}
 
@@ -24219,7 +24219,7 @@ func (op *VmService) Stop(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -24253,7 +24253,7 @@ func (op *VmService) Suspend(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -24288,7 +24288,7 @@ func (op *VmService) ThawFilesystems(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -24345,7 +24345,7 @@ func (op *VmService) Ticket(
 	error) {
 	// Populate the action:
 	action := &Action{
-		Async:  async,
+		Async:  &async,
 		Ticket: ticket,
 	}
 
@@ -24373,7 +24373,7 @@ func (op *VmService) UndoSnapshot(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -25010,7 +25010,7 @@ func (op *VmDiskService) Activate(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -25032,7 +25032,7 @@ func (op *VmDiskService) Deactivate(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -25056,8 +25056,8 @@ func (op *VmDiskService) Export(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:  async,
-		Filter: filter,
+		Async:  &async,
+		Filter: &filter,
 	}
 
 	// Send the request and wait for the response:
@@ -25104,8 +25104,8 @@ func (op *VmDiskService) Move(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:  async,
-		Filter: filter,
+		Async:  &async,
+		Filter: &filter,
 	}
 
 	// Send the request and wait for the response:
@@ -25362,7 +25362,7 @@ func (op *VmGraphicsConsoleService) ProxyTicket(
 	error) {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -25905,7 +25905,7 @@ func (op *VmNicService) Activate(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -25927,7 +25927,7 @@ func (op *VmNicService) Deactivate(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -26518,7 +26518,7 @@ func (op *VmPoolService) AllocateVm(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -28176,8 +28176,8 @@ func (op *AttachedStorageDomainDiskService) Move(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:         async,
-		Filter:        filter,
+		Async:         &async,
+		Filter:        &filter,
 		StorageDomain: storageDomain,
 	}
 
@@ -28392,9 +28392,9 @@ func (op *DiskService) Copy(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:         async,
+		Async:         &async,
 		Disk:          disk,
-		Filter:        filter,
+		Filter:        &filter,
 		StorageDomain: storageDomain,
 	}
 
@@ -28422,8 +28422,8 @@ func (op *DiskService) Export(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:         async,
-		Filter:        filter,
+		Async:         &async,
+		Filter:        &filter,
 		StorageDomain: storageDomain,
 	}
 
@@ -28488,8 +28488,8 @@ func (op *DiskService) Move(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:         async,
-		Filter:        filter,
+		Async:         &async,
+		Filter:        &filter,
 		StorageDomain: storageDomain,
 	}
 
@@ -28821,7 +28821,7 @@ func (op *ExternalHostProviderService) TestConnectivity(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -29062,8 +29062,8 @@ func (op *GlusterBrickService) Replace(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
-		Force: force,
+		Async: &async,
+		Force: &force,
 	}
 
 	// Send the request and wait for the response:
@@ -29233,9 +29233,9 @@ func (op *GlusterVolumeService) Rebalance(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:     async,
-		FixLayout: fixLayout,
-		Force:     force,
+		Async:     &async,
+		FixLayout: &fixLayout,
+		Force:     &force,
 	}
 
 	// Send the request and wait for the response:
@@ -29293,7 +29293,7 @@ func (op *GlusterVolumeService) ResetAllOptions(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -29332,8 +29332,8 @@ func (op *GlusterVolumeService) ResetOption(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:  async,
-		Force:  force,
+		Async:  &async,
+		Force:  &force,
 		Option: option,
 	}
 
@@ -29372,7 +29372,7 @@ func (op *GlusterVolumeService) SetOption(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:  async,
+		Async:  &async,
 		Option: option,
 	}
 
@@ -29405,8 +29405,8 @@ func (op *GlusterVolumeService) Start(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
-		Force: force,
+		Async: &async,
+		Force: &force,
 	}
 
 	// Send the request and wait for the response:
@@ -29434,7 +29434,7 @@ func (op *GlusterVolumeService) StartProfile(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -29464,8 +29464,8 @@ func (op *GlusterVolumeService) Stop(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
-		Force: force,
+		Async: &async,
+		Force: &force,
 	}
 
 	// Send the request and wait for the response:
@@ -29493,7 +29493,7 @@ func (op *GlusterVolumeService) StopProfile(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -29522,7 +29522,7 @@ func (op *GlusterVolumeService) StopRebalance(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -29613,7 +29613,7 @@ func (op *HostService) Activate(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -29638,7 +29638,7 @@ func (op *HostService) Approve(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:   async,
+		Async:   &async,
 		Cluster: cluster,
 	}
 
@@ -29677,7 +29677,7 @@ func (op *HostService) CommitNetConfig(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -29704,9 +29704,9 @@ func (op *HostService) Deactivate(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:              async,
-		Reason:             reason,
-		StopGlusterService: stopGlusterService,
+		Async:              &async,
+		Reason:             &reason,
+		StopGlusterService: &stopGlusterService,
 	}
 
 	// Send the request and wait for the response:
@@ -29729,7 +29729,7 @@ func (op *HostService) EnrollCertificate(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -29777,8 +29777,8 @@ func (op *HostService) Fence(
 	error) {
 	// Populate the action:
 	action := &Action{
-		Async:     async,
-		FenceType: fenceType,
+		Async:     &async,
+		FenceType: &fenceType,
 	}
 
 	// Send the request and wait for the response:
@@ -29815,7 +29815,7 @@ func (op *HostService) ForceSelectSpm(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -29926,13 +29926,13 @@ func (op *HostService) Install(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:                async,
-		DeployHostedEngine:   deployHostedEngine,
+		Async:                &async,
+		DeployHostedEngine:   &deployHostedEngine,
 		Host:                 host,
-		Image:                image,
-		RootPassword:         rootPassword,
+		Image:                &image,
+		RootPassword:         &rootPassword,
 		Ssh:                  ssh,
-		UndeployHostedEngine: undeployHostedEngine,
+		UndeployHostedEngine: &undeployHostedEngine,
 	}
 
 	// Send the request and wait for the response:
@@ -29959,7 +29959,7 @@ func (op *HostService) IscsiDiscover(
 	error) {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 		Iscsi: iscsi,
 	}
 
@@ -29988,7 +29988,7 @@ func (op *HostService) IscsiLogin(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 		Iscsi: iscsi,
 	}
 
@@ -30012,7 +30012,7 @@ func (op *HostService) Refresh(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -30232,9 +30232,9 @@ func (op *HostService) SetupNetworks(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async:                          async,
-		CheckConnectivity:              checkConnectivity,
-		ConnectivityTimeout:            connectivityTimeout,
+		Async:                          &async,
+		CheckConnectivity:              &checkConnectivity,
+		ConnectivityTimeout:            &connectivityTimeout,
 		ModifiedBonds:                  modifiedBonds,
 		ModifiedLabels:                 modifiedLabels,
 		ModifiedNetworkAttachments:     modifiedNetworkAttachments,
@@ -30266,7 +30266,7 @@ func (op *HostService) UnregisteredStorageDomainsDiscover(
 	error) {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 		Iscsi: iscsi,
 	}
 
@@ -30336,7 +30336,7 @@ func (op *HostService) Upgrade(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 	}
 
 	// Send the request and wait for the response:
@@ -30628,7 +30628,7 @@ func (op *HostNicService) UpdateVirtualFunctionsConfiguration(
 	wait bool) error {
 	// Populate the action:
 	action := &Action{
-		Async: async,
+		Async: &async,
 		VirtualFunctionsConfiguration: virtualFunctionsConfiguration,
 	}
 

--- a/sdk/ovirtsdk4/type.go
+++ b/sdk/ovirtsdk4/type.go
@@ -18,11 +18,11 @@ package ovirtsdk4
 
 // Link :
 type Link struct {
-	Href string `xml:"href, attr"`
-	Rel  string `xml:"rel, attr"`
+	Href *string `xml:"href, attr"`
+	Rel  *string `xml:"rel, attr"`
 }
 
 // OvStruct : Base for all struts defined in types.go
 type OvStruct struct {
-	Href string `xml:"href, attr"`
+	Href *string `xml:"href, attr"`
 }

--- a/sdk/ovirtsdk4/types.go
+++ b/sdk/ovirtsdk4/types.go
@@ -28,9 +28,9 @@ type AffinityRules struct {
 
 type AffinityRule struct {
 	OvStruct
-	Enabled   bool `xml:"enabled"`
-	Enforcing bool `xml:"enforcing"`
-	Positive  bool `xml:"positive"`
+	Enabled   *bool `xml:"enabled"`
+	Enforcing *bool `xml:"enforcing"`
+	Positive  *bool `xml:"positive"`
 }
 
 type AgentConfigurations struct {
@@ -40,12 +40,12 @@ type AgentConfigurations struct {
 
 type AgentConfiguration struct {
 	OvStruct
-	Address         string            `xml:"address"`
+	Address         *string           `xml:"address"`
 	BrokerType      MessageBrokerType `xml:"broker_type"`
-	NetworkMappings string            `xml:"network_mappings"`
-	Password        string            `xml:"password"`
-	Port            int64             `xml:"port"`
-	Username        string            `xml:"username"`
+	NetworkMappings *string           `xml:"network_mappings"`
+	Password        *string           `xml:"password"`
+	Port            *int64            `xml:"port"`
+	Username        *string           `xml:"username"`
 }
 
 type Apis struct {
@@ -81,8 +81,8 @@ type ApiSummaryItems struct {
 
 type ApiSummaryItem struct {
 	OvStruct
-	Active int64 `xml:"active"`
-	Total  int64 `xml:"total"`
+	Active *int64 `xml:"active"`
+	Total  *int64 `xml:"total"`
 }
 
 type Bioss struct {
@@ -135,7 +135,7 @@ type BootMenus struct {
 
 type BootMenu struct {
 	OvStruct
-	Enabled bool `xml:"enabled"`
+	Enabled *bool `xml:"enabled"`
 }
 
 type CloudInits struct {
@@ -149,8 +149,8 @@ type CloudInit struct {
 	Files                []File                `xml:"files"`
 	Host                 *Host                 `xml:"host"`
 	NetworkConfiguration *NetworkConfiguration `xml:"network_configuration"`
-	RegenerateSshKeys    bool                  `xml:"regenerate_ssh_keys"`
-	Timezone             string                `xml:"timezone"`
+	RegenerateSshKeys    *bool                 `xml:"regenerate_ssh_keys"`
+	Timezone             *string               `xml:"timezone"`
 	Users                []User                `xml:"users"`
 }
 
@@ -161,7 +161,7 @@ type Configurations struct {
 
 type Configuration struct {
 	OvStruct
-	Data string            `xml:"data"`
+	Data *string           `xml:"data"`
 	Type ConfigurationType `xml:"type"`
 }
 
@@ -172,7 +172,7 @@ type Consoles struct {
 
 type Console struct {
 	OvStruct
-	Enabled bool `xml:"enabled"`
+	Enabled *bool `xml:"enabled"`
 }
 
 type Cores struct {
@@ -182,8 +182,8 @@ type Cores struct {
 
 type Core struct {
 	OvStruct
-	Index  int64 `xml:"index"`
-	Socket int64 `xml:"socket"`
+	Index  *int64 `xml:"index"`
+	Socket *int64 `xml:"socket"`
 }
 
 type Cpus struct {
@@ -196,12 +196,12 @@ type Cpu struct {
 	Architecture Architecture `xml:"architecture"`
 	Cores        []Core       `xml:"cores"`
 	CpuTune      *CpuTune     `xml:"cpu_tune"`
-	Level        int64        `xml:"level"`
+	Level        *int64       `xml:"level"`
 	Mode         CpuMode      `xml:"mode"`
-	Name         string       `xml:"name"`
-	Speed        float64      `xml:"speed"`
+	Name         *string      `xml:"name"`
+	Speed        *float64     `xml:"speed"`
 	Topology     *CpuTopology `xml:"topology"`
-	Type         string       `xml:"type"`
+	Type         *string      `xml:"type"`
 }
 
 type CpuTopologys struct {
@@ -211,9 +211,9 @@ type CpuTopologys struct {
 
 type CpuTopology struct {
 	OvStruct
-	Cores   int64 `xml:"cores"`
-	Sockets int64 `xml:"sockets"`
-	Threads int64 `xml:"threads"`
+	Cores   *int64 `xml:"cores"`
+	Sockets *int64 `xml:"sockets"`
+	Threads *int64 `xml:"threads"`
 }
 
 type CpuTunes struct {
@@ -234,8 +234,8 @@ type CpuTypes struct {
 type CpuType struct {
 	OvStruct
 	Architecture Architecture `xml:"architecture"`
-	Level        int64        `xml:"level"`
-	Name         string       `xml:"name"`
+	Level        *int64       `xml:"level"`
+	Name         *string      `xml:"name"`
 }
 
 type CustomPropertys struct {
@@ -245,9 +245,9 @@ type CustomPropertys struct {
 
 type CustomProperty struct {
 	OvStruct
-	Name   string `xml:"name"`
-	Regexp string `xml:"regexp"`
-	Value  string `xml:"value"`
+	Name   *string `xml:"name"`
+	Regexp *string `xml:"regexp"`
+	Value  *string `xml:"value"`
 }
 
 type Displays struct {
@@ -257,19 +257,19 @@ type Displays struct {
 
 type Display struct {
 	OvStruct
-	Address             string       `xml:"address"`
-	AllowOverride       bool         `xml:"allow_override"`
+	Address             *string      `xml:"address"`
+	AllowOverride       *bool        `xml:"allow_override"`
 	Certificate         *Certificate `xml:"certificate"`
-	CopyPasteEnabled    bool         `xml:"copy_paste_enabled"`
-	DisconnectAction    string       `xml:"disconnect_action"`
-	FileTransferEnabled bool         `xml:"file_transfer_enabled"`
-	KeyboardLayout      string       `xml:"keyboard_layout"`
-	Monitors            int64        `xml:"monitors"`
-	Port                int64        `xml:"port"`
-	Proxy               string       `xml:"proxy"`
-	SecurePort          int64        `xml:"secure_port"`
-	SingleQxlPci        bool         `xml:"single_qxl_pci"`
-	SmartcardEnabled    bool         `xml:"smartcard_enabled"`
+	CopyPasteEnabled    *bool        `xml:"copy_paste_enabled"`
+	DisconnectAction    *string      `xml:"disconnect_action"`
+	FileTransferEnabled *bool        `xml:"file_transfer_enabled"`
+	KeyboardLayout      *string      `xml:"keyboard_layout"`
+	Monitors            *int64       `xml:"monitors"`
+	Port                *int64       `xml:"port"`
+	Proxy               *string      `xml:"proxy"`
+	SecurePort          *int64       `xml:"secure_port"`
+	SingleQxlPci        *bool        `xml:"single_qxl_pci"`
+	SmartcardEnabled    *bool        `xml:"smartcard_enabled"`
 	Type                DisplayType  `xml:"type"`
 }
 
@@ -325,14 +325,14 @@ type ExternalVmImport struct {
 	CpuProfile    *CpuProfile            `xml:"cpu_profile"`
 	DriversIso    *File                  `xml:"drivers_iso"`
 	Host          *Host                  `xml:"host"`
-	Name          string                 `xml:"name"`
-	Password      string                 `xml:"password"`
+	Name          *string                `xml:"name"`
+	Password      *string                `xml:"password"`
 	Provider      ExternalVmProviderType `xml:"provider"`
 	Quota         *Quota                 `xml:"quota"`
-	Sparse        bool                   `xml:"sparse"`
+	Sparse        *bool                  `xml:"sparse"`
 	StorageDomain *StorageDomain         `xml:"storage_domain"`
-	Url           string                 `xml:"url"`
-	Username      string                 `xml:"username"`
+	Url           *string                `xml:"url"`
+	Username      *string                `xml:"username"`
 	Vm            *Vm                    `xml:"vm"`
 }
 
@@ -343,8 +343,8 @@ type Faults struct {
 
 type Fault struct {
 	OvStruct
-	Detail string `xml:"detail"`
-	Reason string `xml:"reason"`
+	Detail *string `xml:"detail"`
+	Reason *string `xml:"reason"`
 }
 
 type FencingPolicys struct {
@@ -354,10 +354,10 @@ type FencingPolicys struct {
 
 type FencingPolicy struct {
 	OvStruct
-	Enabled                   bool                      `xml:"enabled"`
+	Enabled                   *bool                     `xml:"enabled"`
 	SkipIfConnectivityBroken  *SkipIfConnectivityBroken `xml:"skip_if_connectivity_broken"`
-	SkipIfGlusterBricksUp     bool                      `xml:"skip_if_gluster_bricks_up"`
-	SkipIfGlusterQuorumNotMet bool                      `xml:"skip_if_gluster_quorum_not_met"`
+	SkipIfGlusterBricksUp     *bool                     `xml:"skip_if_gluster_bricks_up"`
+	SkipIfGlusterQuorumNotMet *bool                     `xml:"skip_if_gluster_quorum_not_met"`
 	SkipIfSdActive            *SkipIfSdActive           `xml:"skip_if_sd_active"`
 }
 
@@ -368,7 +368,7 @@ type FopStatistics struct {
 
 type FopStatistic struct {
 	OvStruct
-	Name       string      `xml:"name"`
+	Name       *string     `xml:"name"`
 	Statistics []Statistic `xml:"statistics"`
 }
 
@@ -389,10 +389,10 @@ type GlusterClients struct {
 
 type GlusterClient struct {
 	OvStruct
-	BytesRead    int64  `xml:"bytes_read"`
-	BytesWritten int64  `xml:"bytes_written"`
-	ClientPort   int64  `xml:"client_port"`
-	HostName     string `xml:"host_name"`
+	BytesRead    *int64  `xml:"bytes_read"`
+	BytesWritten *int64  `xml:"bytes_written"`
+	ClientPort   *int64  `xml:"client_port"`
+	HostName     *string `xml:"host_name"`
 }
 
 type GracePeriods struct {
@@ -402,7 +402,7 @@ type GracePeriods struct {
 
 type GracePeriod struct {
 	OvStruct
-	Expiry int64 `xml:"expiry"`
+	Expiry *int64 `xml:"expiry"`
 }
 
 type GuestOperatingSystems struct {
@@ -412,10 +412,10 @@ type GuestOperatingSystems struct {
 
 type GuestOperatingSystem struct {
 	OvStruct
-	Architecture string   `xml:"architecture"`
-	Codename     string   `xml:"codename"`
-	Distribution string   `xml:"distribution"`
-	Family       string   `xml:"family"`
+	Architecture *string  `xml:"architecture"`
+	Codename     *string  `xml:"codename"`
+	Distribution *string  `xml:"distribution"`
+	Family       *string  `xml:"family"`
 	Kernel       *Kernel  `xml:"kernel"`
 	Version      *Version `xml:"version"`
 }
@@ -427,13 +427,13 @@ type HardwareInformations struct {
 
 type HardwareInformation struct {
 	OvStruct
-	Family              string      `xml:"family"`
-	Manufacturer        string      `xml:"manufacturer"`
-	ProductName         string      `xml:"product_name"`
-	SerialNumber        string      `xml:"serial_number"`
+	Family              *string     `xml:"family"`
+	Manufacturer        *string     `xml:"manufacturer"`
+	ProductName         *string     `xml:"product_name"`
+	SerialNumber        *string     `xml:"serial_number"`
 	SupportedRngSources []RngSource `xml:"supported_rng_sources"`
-	Uuid                string      `xml:"uuid"`
-	Version             string      `xml:"version"`
+	Uuid                *string     `xml:"uuid"`
+	Version             *string     `xml:"version"`
 }
 
 type HighAvailabilitys struct {
@@ -443,8 +443,8 @@ type HighAvailabilitys struct {
 
 type HighAvailability struct {
 	OvStruct
-	Enabled  bool  `xml:"enabled"`
-	Priority int64 `xml:"priority"`
+	Enabled  *bool  `xml:"enabled"`
+	Priority *int64 `xml:"priority"`
 }
 
 type HostDevicePassthroughs struct {
@@ -454,7 +454,7 @@ type HostDevicePassthroughs struct {
 
 type HostDevicePassthrough struct {
 	OvStruct
-	Enabled bool `xml:"enabled"`
+	Enabled *bool `xml:"enabled"`
 }
 
 type HostNicVirtualFunctionsConfigurations struct {
@@ -464,9 +464,9 @@ type HostNicVirtualFunctionsConfigurations struct {
 
 type HostNicVirtualFunctionsConfiguration struct {
 	OvStruct
-	AllNetworksAllowed          bool  `xml:"all_networks_allowed"`
-	MaxNumberOfVirtualFunctions int64 `xml:"max_number_of_virtual_functions"`
-	NumberOfVirtualFunctions    int64 `xml:"number_of_virtual_functions"`
+	AllNetworksAllowed          *bool  `xml:"all_networks_allowed"`
+	MaxNumberOfVirtualFunctions *int64 `xml:"max_number_of_virtual_functions"`
+	NumberOfVirtualFunctions    *int64 `xml:"number_of_virtual_functions"`
 }
 
 type HostedEngines struct {
@@ -476,11 +476,11 @@ type HostedEngines struct {
 
 type HostedEngine struct {
 	OvStruct
-	Active            bool  `xml:"active"`
-	Configured        bool  `xml:"configured"`
-	GlobalMaintenance bool  `xml:"global_maintenance"`
-	LocalMaintenance  bool  `xml:"local_maintenance"`
-	Score             int64 `xml:"score"`
+	Active            *bool  `xml:"active"`
+	Configured        *bool  `xml:"configured"`
+	GlobalMaintenance *bool  `xml:"global_maintenance"`
+	LocalMaintenance  *bool  `xml:"local_maintenance"`
+	Score             *int64 `xml:"score"`
 }
 
 type Identifieds struct {
@@ -490,10 +490,10 @@ type Identifieds struct {
 
 type Identified struct {
 	OvStruct
-	Comment     string `xml:"comment"`
-	Description string `xml:"description"`
-	Id          string `xml:"id,attr"`
-	Name        string `xml:"name"`
+	Comment     *string `xml:"comment"`
+	Description *string `xml:"description"`
+	Id          *string `xml:"id,attr"`
+	Name        *string `xml:"name"`
 }
 
 type Images struct {
@@ -503,10 +503,10 @@ type Images struct {
 
 type Image struct {
 	OvStruct
-	Comment       string         `xml:"comment"`
-	Description   string         `xml:"description"`
-	Id            string         `xml:"id,attr"`
-	Name          string         `xml:"name"`
+	Comment       *string        `xml:"comment"`
+	Description   *string        `xml:"description"`
+	Id            *string        `xml:"id,attr"`
+	Name          *string        `xml:"name"`
 	StorageDomain *StorageDomain `xml:"storage_domain"`
 }
 
@@ -517,16 +517,16 @@ type ImageTransfers struct {
 
 type ImageTransfer struct {
 	OvStruct
-	Comment      string                 `xml:"comment"`
-	Description  string                 `xml:"description"`
+	Comment      *string                `xml:"comment"`
+	Description  *string                `xml:"description"`
 	Direction    ImageTransferDirection `xml:"direction"`
 	Host         *Host                  `xml:"host"`
-	Id           string                 `xml:"id,attr"`
+	Id           *string                `xml:"id,attr"`
 	Image        *Image                 `xml:"image"`
-	Name         string                 `xml:"name"`
+	Name         *string                `xml:"name"`
 	Phase        ImageTransferPhase     `xml:"phase"`
-	ProxyUrl     string                 `xml:"proxy_url"`
-	SignedTicket string                 `xml:"signed_ticket"`
+	ProxyUrl     *string                `xml:"proxy_url"`
+	SignedTicket *string                `xml:"signed_ticket"`
 }
 
 type Initializations struct {
@@ -536,27 +536,27 @@ type Initializations struct {
 
 type Initialization struct {
 	OvStruct
-	ActiveDirectoryOu string             `xml:"active_directory_ou"`
-	AuthorizedSshKeys string             `xml:"authorized_ssh_keys"`
+	ActiveDirectoryOu *string            `xml:"active_directory_ou"`
+	AuthorizedSshKeys *string            `xml:"authorized_ssh_keys"`
 	CloudInit         *CloudInit         `xml:"cloud_init"`
 	Configuration     *Configuration     `xml:"configuration"`
-	CustomScript      string             `xml:"custom_script"`
-	DnsSearch         string             `xml:"dns_search"`
-	DnsServers        string             `xml:"dns_servers"`
-	Domain            string             `xml:"domain"`
-	HostName          string             `xml:"host_name"`
-	InputLocale       string             `xml:"input_locale"`
+	CustomScript      *string            `xml:"custom_script"`
+	DnsSearch         *string            `xml:"dns_search"`
+	DnsServers        *string            `xml:"dns_servers"`
+	Domain            *string            `xml:"domain"`
+	HostName          *string            `xml:"host_name"`
+	InputLocale       *string            `xml:"input_locale"`
 	NicConfigurations []NicConfiguration `xml:"nic_configurations"`
-	OrgName           string             `xml:"org_name"`
-	RegenerateIds     bool               `xml:"regenerate_ids"`
-	RegenerateSshKeys bool               `xml:"regenerate_ssh_keys"`
-	RootPassword      string             `xml:"root_password"`
-	SystemLocale      string             `xml:"system_locale"`
-	Timezone          string             `xml:"timezone"`
-	UiLanguage        string             `xml:"ui_language"`
-	UserLocale        string             `xml:"user_locale"`
-	UserName          string             `xml:"user_name"`
-	WindowsLicenseKey string             `xml:"windows_license_key"`
+	OrgName           *string            `xml:"org_name"`
+	RegenerateIds     *bool              `xml:"regenerate_ids"`
+	RegenerateSshKeys *bool              `xml:"regenerate_ssh_keys"`
+	RootPassword      *string            `xml:"root_password"`
+	SystemLocale      *string            `xml:"system_locale"`
+	Timezone          *string            `xml:"timezone"`
+	UiLanguage        *string            `xml:"ui_language"`
+	UserLocale        *string            `xml:"user_locale"`
+	UserName          *string            `xml:"user_name"`
+	WindowsLicenseKey *string            `xml:"windows_license_key"`
 }
 
 type Ios struct {
@@ -566,7 +566,7 @@ type Ios struct {
 
 type Io struct {
 	OvStruct
-	Threads int64 `xml:"threads"`
+	Threads *int64 `xml:"threads"`
 }
 
 type Ips struct {
@@ -576,9 +576,9 @@ type Ips struct {
 
 type Ip struct {
 	OvStruct
-	Address string    `xml:"address"`
-	Gateway string    `xml:"gateway"`
-	Netmask string    `xml:"netmask"`
+	Address *string   `xml:"address"`
+	Gateway *string   `xml:"gateway"`
+	Netmask *string   `xml:"netmask"`
 	Version IpVersion `xml:"version"`
 }
 
@@ -600,11 +600,11 @@ type IscsiBonds struct {
 
 type IscsiBond struct {
 	OvStruct
-	Comment            string              `xml:"comment"`
+	Comment            *string             `xml:"comment"`
 	DataCenter         *DataCenter         `xml:"data_center"`
-	Description        string              `xml:"description"`
-	Id                 string              `xml:"id,attr"`
-	Name               string              `xml:"name"`
+	Description        *string             `xml:"description"`
+	Id                 *string             `xml:"id,attr"`
+	Name               *string             `xml:"name"`
 	Networks           []Network           `xml:"networks"`
 	StorageConnections []StorageConnection `xml:"storage_connections"`
 }
@@ -616,23 +616,23 @@ type IscsiDetailss struct {
 
 type IscsiDetails struct {
 	OvStruct
-	Address         string `xml:"address"`
-	DiskId          string `xml:"disk_id"`
-	Initiator       string `xml:"initiator"`
-	LunMapping      int64  `xml:"lun_mapping"`
-	Password        string `xml:"password"`
-	Paths           int64  `xml:"paths"`
-	Port            int64  `xml:"port"`
-	Portal          string `xml:"portal"`
-	ProductId       string `xml:"product_id"`
-	Serial          string `xml:"serial"`
-	Size            int64  `xml:"size"`
-	Status          string `xml:"status"`
-	StorageDomainId string `xml:"storage_domain_id"`
-	Target          string `xml:"target"`
-	Username        string `xml:"username"`
-	VendorId        string `xml:"vendor_id"`
-	VolumeGroupId   string `xml:"volume_group_id"`
+	Address         *string `xml:"address"`
+	DiskId          *string `xml:"disk_id"`
+	Initiator       *string `xml:"initiator"`
+	LunMapping      *int64  `xml:"lun_mapping"`
+	Password        *string `xml:"password"`
+	Paths           *int64  `xml:"paths"`
+	Port            *int64  `xml:"port"`
+	Portal          *string `xml:"portal"`
+	ProductId       *string `xml:"product_id"`
+	Serial          *string `xml:"serial"`
+	Size            *int64  `xml:"size"`
+	Status          *string `xml:"status"`
+	StorageDomainId *string `xml:"storage_domain_id"`
+	Target          *string `xml:"target"`
+	Username        *string `xml:"username"`
+	VendorId        *string `xml:"vendor_id"`
+	VolumeGroupId   *string `xml:"volume_group_id"`
 }
 
 type Jobs struct {
@@ -642,14 +642,14 @@ type Jobs struct {
 
 type Job struct {
 	OvStruct
-	AutoCleared bool      `xml:"auto_cleared"`
-	Comment     string    `xml:"comment"`
-	Description string    `xml:"description"`
+	AutoCleared *bool     `xml:"auto_cleared"`
+	Comment     *string   `xml:"comment"`
+	Description *string   `xml:"description"`
 	EndTime     time.Time `xml:"end_time"`
-	External    bool      `xml:"external"`
-	Id          string    `xml:"id,attr"`
+	External    *bool     `xml:"external"`
+	Id          *string   `xml:"id,attr"`
 	LastUpdated time.Time `xml:"last_updated"`
-	Name        string    `xml:"name"`
+	Name        *string   `xml:"name"`
 	Owner       *User     `xml:"owner"`
 	StartTime   time.Time `xml:"start_time"`
 	Status      JobStatus `xml:"status"`
@@ -663,18 +663,18 @@ type KatelloErratums struct {
 
 type KatelloErratum struct {
 	OvStruct
-	Comment     string    `xml:"comment"`
-	Description string    `xml:"description"`
+	Comment     *string   `xml:"comment"`
+	Description *string   `xml:"description"`
 	Host        *Host     `xml:"host"`
-	Id          string    `xml:"id,attr"`
+	Id          *string   `xml:"id,attr"`
 	Issued      time.Time `xml:"issued"`
-	Name        string    `xml:"name"`
+	Name        *string   `xml:"name"`
 	Packages    []Package `xml:"packages"`
-	Severity    string    `xml:"severity"`
-	Solution    string    `xml:"solution"`
-	Summary     string    `xml:"summary"`
-	Title       string    `xml:"title"`
-	Type        string    `xml:"type"`
+	Severity    *string   `xml:"severity"`
+	Solution    *string   `xml:"solution"`
+	Summary     *string   `xml:"summary"`
+	Title       *string   `xml:"title"`
+	Type        *string   `xml:"type"`
 	Vm          *Vm       `xml:"vm"`
 }
 
@@ -695,8 +695,8 @@ type Ksms struct {
 
 type Ksm struct {
 	OvStruct
-	Enabled          bool `xml:"enabled"`
-	MergeAcrossNodes bool `xml:"merge_across_nodes"`
+	Enabled          *bool `xml:"enabled"`
+	MergeAcrossNodes *bool `xml:"merge_across_nodes"`
 }
 
 type LogicalUnits struct {
@@ -706,25 +706,25 @@ type LogicalUnits struct {
 
 type LogicalUnit struct {
 	OvStruct
-	Address           string    `xml:"address"`
-	DiscardMaxSize    int64     `xml:"discard_max_size"`
-	DiscardZeroesData bool      `xml:"discard_zeroes_data"`
-	DiskId            string    `xml:"disk_id"`
-	Id                string    `xml:"id,attr"`
-	LunMapping        int64     `xml:"lun_mapping"`
-	Password          string    `xml:"password"`
-	Paths             int64     `xml:"paths"`
-	Port              int64     `xml:"port"`
-	Portal            string    `xml:"portal"`
-	ProductId         string    `xml:"product_id"`
-	Serial            string    `xml:"serial"`
-	Size              int64     `xml:"size"`
+	Address           *string   `xml:"address"`
+	DiscardMaxSize    *int64    `xml:"discard_max_size"`
+	DiscardZeroesData *bool     `xml:"discard_zeroes_data"`
+	DiskId            *string   `xml:"disk_id"`
+	Id                *string   `xml:"id,attr"`
+	LunMapping        *int64    `xml:"lun_mapping"`
+	Password          *string   `xml:"password"`
+	Paths             *int64    `xml:"paths"`
+	Port              *int64    `xml:"port"`
+	Portal            *string   `xml:"portal"`
+	ProductId         *string   `xml:"product_id"`
+	Serial            *string   `xml:"serial"`
+	Size              *int64    `xml:"size"`
 	Status            LunStatus `xml:"status"`
-	StorageDomainId   string    `xml:"storage_domain_id"`
-	Target            string    `xml:"target"`
-	Username          string    `xml:"username"`
-	VendorId          string    `xml:"vendor_id"`
-	VolumeGroupId     string    `xml:"volume_group_id"`
+	StorageDomainId   *string   `xml:"storage_domain_id"`
+	Target            *string   `xml:"target"`
+	Username          *string   `xml:"username"`
+	VendorId          *string   `xml:"vendor_id"`
+	VolumeGroupId     *string   `xml:"volume_group_id"`
 }
 
 type Macs struct {
@@ -734,7 +734,7 @@ type Macs struct {
 
 type Mac struct {
 	OvStruct
-	Address string `xml:"address"`
+	Address *string `xml:"address"`
 }
 
 type MacPools struct {
@@ -744,12 +744,12 @@ type MacPools struct {
 
 type MacPool struct {
 	OvStruct
-	AllowDuplicates bool    `xml:"allow_duplicates"`
-	Comment         string  `xml:"comment"`
-	DefaultPool     bool    `xml:"default_pool"`
-	Description     string  `xml:"description"`
-	Id              string  `xml:"id,attr"`
-	Name            string  `xml:"name"`
+	AllowDuplicates *bool   `xml:"allow_duplicates"`
+	Comment         *string `xml:"comment"`
+	DefaultPool     *bool   `xml:"default_pool"`
+	Description     *string `xml:"description"`
+	Id              *string `xml:"id,attr"`
+	Name            *string `xml:"name"`
 	Ranges          []Range `xml:"ranges"`
 }
 
@@ -760,7 +760,7 @@ type MemoryOverCommits struct {
 
 type MemoryOverCommit struct {
 	OvStruct
-	Percent int64 `xml:"percent"`
+	Percent *int64 `xml:"percent"`
 }
 
 type MemoryPolicys struct {
@@ -770,9 +770,9 @@ type MemoryPolicys struct {
 
 type MemoryPolicy struct {
 	OvStruct
-	Ballooning           bool                  `xml:"ballooning"`
-	Guaranteed           int64                 `xml:"guaranteed"`
-	Max                  int64                 `xml:"max"`
+	Ballooning           *bool                 `xml:"ballooning"`
+	Guaranteed           *int64                `xml:"guaranteed"`
+	Max                  *int64                `xml:"max"`
 	OverCommit           *MemoryOverCommit     `xml:"over_commit"`
 	TransparentHugePages *TransparentHugePages `xml:"transparent_huge_pages"`
 }
@@ -795,7 +795,7 @@ type MigrationBandwidths struct {
 type MigrationBandwidth struct {
 	OvStruct
 	AssignmentMethod MigrationBandwidthAssignmentMethod `xml:"assignment_method"`
-	CustomValue      int64                              `xml:"custom_value"`
+	CustomValue      *int64                             `xml:"custom_value"`
 }
 
 type MigrationOptionss struct {
@@ -818,10 +818,10 @@ type MigrationPolicys struct {
 
 type MigrationPolicy struct {
 	OvStruct
-	Comment     string `xml:"comment"`
-	Description string `xml:"description"`
-	Id          string `xml:"id,attr"`
-	Name        string `xml:"name"`
+	Comment     *string `xml:"comment"`
+	Description *string `xml:"description"`
+	Id          *string `xml:"id,attr"`
+	Name        *string `xml:"name"`
 }
 
 type Networks struct {
@@ -832,22 +832,22 @@ type Networks struct {
 type Network struct {
 	OvStruct
 	Cluster                  *Cluster                  `xml:"cluster"`
-	Comment                  string                    `xml:"comment"`
+	Comment                  *string                   `xml:"comment"`
 	DataCenter               *DataCenter               `xml:"data_center"`
-	Description              string                    `xml:"description"`
-	Display                  bool                      `xml:"display"`
+	Description              *string                   `xml:"description"`
+	Display                  *bool                     `xml:"display"`
 	DnsResolverConfiguration *DnsResolverConfiguration `xml:"dns_resolver_configuration"`
-	Id                       string                    `xml:"id,attr"`
+	Id                       *string                   `xml:"id,attr"`
 	Ip                       *Ip                       `xml:"ip"`
-	Mtu                      int64                     `xml:"mtu"`
-	Name                     string                    `xml:"name"`
+	Mtu                      *int64                    `xml:"mtu"`
+	Name                     *string                   `xml:"name"`
 	NetworkLabels            []NetworkLabel            `xml:"network_labels"`
 	Permissions              []Permission              `xml:"permissions"`
-	ProfileRequired          bool                      `xml:"profile_required"`
+	ProfileRequired          *bool                     `xml:"profile_required"`
 	Qos                      *Qos                      `xml:"qos"`
-	Required                 bool                      `xml:"required"`
+	Required                 *bool                     `xml:"required"`
 	Status                   NetworkStatus             `xml:"status"`
-	Stp                      bool                      `xml:"stp"`
+	Stp                      *bool                     `xml:"stp"`
 	Usages                   []NetworkUsage            `xml:"usages"`
 	Vlan                     *Vlan                     `xml:"vlan"`
 	VnicProfiles             []VnicProfile             `xml:"vnic_profiles"`
@@ -860,15 +860,15 @@ type NetworkAttachments struct {
 
 type NetworkAttachment struct {
 	OvStruct
-	Comment                  string                    `xml:"comment"`
-	Description              string                    `xml:"description"`
+	Comment                  *string                   `xml:"comment"`
+	Description              *string                   `xml:"description"`
 	DnsResolverConfiguration *DnsResolverConfiguration `xml:"dns_resolver_configuration"`
 	Host                     *Host                     `xml:"host"`
 	HostNic                  *HostNic                  `xml:"host_nic"`
-	Id                       string                    `xml:"id,attr"`
-	InSync                   bool                      `xml:"in_sync"`
+	Id                       *string                   `xml:"id,attr"`
+	InSync                   *bool                     `xml:"in_sync"`
 	IpAddressAssignments     []IpAddressAssignment     `xml:"ip_address_assignments"`
-	Name                     string                    `xml:"name"`
+	Name                     *string                   `xml:"name"`
 	Network                  *Network                  `xml:"network"`
 	Properties               []Property                `xml:"properties"`
 	Qos                      *Qos                      `xml:"qos"`
@@ -893,10 +893,10 @@ type NetworkFilters struct {
 
 type NetworkFilter struct {
 	OvStruct
-	Comment     string   `xml:"comment"`
-	Description string   `xml:"description"`
-	Id          string   `xml:"id,attr"`
-	Name        string   `xml:"name"`
+	Comment     *string  `xml:"comment"`
+	Description *string  `xml:"description"`
+	Id          *string  `xml:"id,attr"`
+	Name        *string  `xml:"name"`
 	Version     *Version `xml:"version"`
 }
 
@@ -907,11 +907,11 @@ type NetworkFilterParameters struct {
 
 type NetworkFilterParameter struct {
 	OvStruct
-	Comment     string `xml:"comment"`
-	Description string `xml:"description"`
-	Id          string `xml:"id,attr"`
-	Name        string `xml:"name"`
-	Value       string `xml:"value"`
+	Comment     *string `xml:"comment"`
+	Description *string `xml:"description"`
+	Id          *string `xml:"id,attr"`
+	Name        *string `xml:"name"`
+	Value       *string `xml:"value"`
 }
 
 type NetworkLabels struct {
@@ -921,11 +921,11 @@ type NetworkLabels struct {
 
 type NetworkLabel struct {
 	OvStruct
-	Comment     string   `xml:"comment"`
-	Description string   `xml:"description"`
+	Comment     *string  `xml:"comment"`
+	Description *string  `xml:"description"`
 	HostNic     *HostNic `xml:"host_nic"`
-	Id          string   `xml:"id,attr"`
-	Name        string   `xml:"name"`
+	Id          *string  `xml:"id,attr"`
+	Name        *string  `xml:"name"`
 	Network     *Network `xml:"network"`
 }
 
@@ -936,7 +936,7 @@ type NfsProfileDetails struct {
 
 type NfsProfileDetail struct {
 	OvStruct
-	NfsServerIp    string          `xml:"nfs_server_ip"`
+	NfsServerIp    *string         `xml:"nfs_server_ip"`
 	ProfileDetails []ProfileDetail `xml:"profile_details"`
 }
 
@@ -951,8 +951,8 @@ type NicConfiguration struct {
 	Ip               *Ip          `xml:"ip"`
 	Ipv6             *Ip          `xml:"ipv6"`
 	Ipv6BootProtocol BootProtocol `xml:"ipv6_boot_protocol"`
-	Name             string       `xml:"name"`
-	OnBoot           bool         `xml:"on_boot"`
+	Name             *string      `xml:"name"`
+	OnBoot           *bool        `xml:"on_boot"`
 }
 
 type NumaNodes struct {
@@ -962,15 +962,15 @@ type NumaNodes struct {
 
 type NumaNode struct {
 	OvStruct
-	Comment      string      `xml:"comment"`
+	Comment      *string     `xml:"comment"`
 	Cpu          *Cpu        `xml:"cpu"`
-	Description  string      `xml:"description"`
+	Description  *string     `xml:"description"`
 	Host         *Host       `xml:"host"`
-	Id           string      `xml:"id,attr"`
-	Index        int64       `xml:"index"`
-	Memory       int64       `xml:"memory"`
-	Name         string      `xml:"name"`
-	NodeDistance string      `xml:"node_distance"`
+	Id           *string     `xml:"id,attr"`
+	Index        *int64      `xml:"index"`
+	Memory       *int64      `xml:"memory"`
+	Name         *string     `xml:"name"`
+	NodeDistance *string     `xml:"node_distance"`
 	Statistics   []Statistic `xml:"statistics"`
 }
 
@@ -982,8 +982,8 @@ type NumaNodePins struct {
 type NumaNodePin struct {
 	OvStruct
 	HostNumaNode *NumaNode `xml:"host_numa_node"`
-	Index        int64     `xml:"index"`
-	Pinned       bool      `xml:"pinned"`
+	Index        *int64    `xml:"index"`
+	Pinned       *bool     `xml:"pinned"`
 }
 
 type OpenStackImages struct {
@@ -993,10 +993,10 @@ type OpenStackImages struct {
 
 type OpenStackImage struct {
 	OvStruct
-	Comment                string                  `xml:"comment"`
-	Description            string                  `xml:"description"`
-	Id                     string                  `xml:"id,attr"`
-	Name                   string                  `xml:"name"`
+	Comment                *string                 `xml:"comment"`
+	Description            *string                 `xml:"description"`
+	Id                     *string                 `xml:"id,attr"`
+	Name                   *string                 `xml:"name"`
 	OpenstackImageProvider *OpenStackImageProvider `xml:"openstack_image_provider"`
 }
 
@@ -1007,10 +1007,10 @@ type OpenStackNetworks struct {
 
 type OpenStackNetwork struct {
 	OvStruct
-	Comment                  string                    `xml:"comment"`
-	Description              string                    `xml:"description"`
-	Id                       string                    `xml:"id,attr"`
-	Name                     string                    `xml:"name"`
+	Comment                  *string                   `xml:"comment"`
+	Description              *string                   `xml:"description"`
+	Id                       *string                   `xml:"id,attr"`
+	Name                     *string                   `xml:"name"`
 	OpenstackNetworkProvider *OpenStackNetworkProvider `xml:"openstack_network_provider"`
 }
 
@@ -1021,14 +1021,14 @@ type OpenStackSubnets struct {
 
 type OpenStackSubnet struct {
 	OvStruct
-	Cidr             string            `xml:"cidr"`
-	Comment          string            `xml:"comment"`
-	Description      string            `xml:"description"`
+	Cidr             *string           `xml:"cidr"`
+	Comment          *string           `xml:"comment"`
+	Description      *string           `xml:"description"`
 	DnsServers       []string          `xml:"dns_servers"`
-	Gateway          string            `xml:"gateway"`
-	Id               string            `xml:"id,attr"`
-	IpVersion        string            `xml:"ip_version"`
-	Name             string            `xml:"name"`
+	Gateway          *string           `xml:"gateway"`
+	Id               *string           `xml:"id,attr"`
+	IpVersion        *string           `xml:"ip_version"`
+	Name             *string           `xml:"name"`
 	OpenstackNetwork *OpenStackNetwork `xml:"openstack_network"`
 }
 
@@ -1039,10 +1039,10 @@ type OpenStackVolumeTypes struct {
 
 type OpenStackVolumeType struct {
 	OvStruct
-	Comment                 string                   `xml:"comment"`
-	Description             string                   `xml:"description"`
-	Id                      string                   `xml:"id,attr"`
-	Name                    string                   `xml:"name"`
+	Comment                 *string                  `xml:"comment"`
+	Description             *string                  `xml:"description"`
+	Id                      *string                  `xml:"id,attr"`
+	Name                    *string                  `xml:"name"`
 	OpenstackVolumeProvider *OpenStackVolumeProvider `xml:"openstack_volume_provider"`
 	Properties              []Property               `xml:"properties"`
 }
@@ -1054,15 +1054,15 @@ type OpenstackVolumeAuthenticationKeys struct {
 
 type OpenstackVolumeAuthenticationKey struct {
 	OvStruct
-	Comment                 string                                    `xml:"comment"`
+	Comment                 *string                                   `xml:"comment"`
 	CreationDate            time.Time                                 `xml:"creation_date"`
-	Description             string                                    `xml:"description"`
-	Id                      string                                    `xml:"id,attr"`
-	Name                    string                                    `xml:"name"`
+	Description             *string                                   `xml:"description"`
+	Id                      *string                                   `xml:"id,attr"`
+	Name                    *string                                   `xml:"name"`
 	OpenstackVolumeProvider *OpenStackVolumeProvider                  `xml:"openstack_volume_provider"`
 	UsageType               OpenstackVolumeAuthenticationKeyUsageType `xml:"usage_type"`
-	Uuid                    string                                    `xml:"uuid"`
-	Value                   string                                    `xml:"value"`
+	Uuid                    *string                                   `xml:"uuid"`
+	Value                   *string                                   `xml:"value"`
 }
 
 type OperatingSystems struct {
@@ -1073,12 +1073,12 @@ type OperatingSystems struct {
 type OperatingSystem struct {
 	OvStruct
 	Boot                  *Boot    `xml:"boot"`
-	Cmdline               string   `xml:"cmdline"`
-	CustomKernelCmdline   string   `xml:"custom_kernel_cmdline"`
-	Initrd                string   `xml:"initrd"`
-	Kernel                string   `xml:"kernel"`
-	ReportedKernelCmdline string   `xml:"reported_kernel_cmdline"`
-	Type                  string   `xml:"type"`
+	Cmdline               *string  `xml:"cmdline"`
+	CustomKernelCmdline   *string  `xml:"custom_kernel_cmdline"`
+	Initrd                *string  `xml:"initrd"`
+	Kernel                *string  `xml:"kernel"`
+	ReportedKernelCmdline *string  `xml:"reported_kernel_cmdline"`
+	Type                  *string  `xml:"type"`
 	Version               *Version `xml:"version"`
 }
 
@@ -1089,12 +1089,12 @@ type OperatingSystemInfos struct {
 
 type OperatingSystemInfo struct {
 	OvStruct
-	Comment     string `xml:"comment"`
-	Description string `xml:"description"`
-	Id          string `xml:"id,attr"`
-	LargeIcon   *Icon  `xml:"large_icon"`
-	Name        string `xml:"name"`
-	SmallIcon   *Icon  `xml:"small_icon"`
+	Comment     *string `xml:"comment"`
+	Description *string `xml:"description"`
+	Id          *string `xml:"id,attr"`
+	LargeIcon   *Icon   `xml:"large_icon"`
+	Name        *string `xml:"name"`
+	SmallIcon   *Icon   `xml:"small_icon"`
 }
 
 type Options struct {
@@ -1104,9 +1104,9 @@ type Options struct {
 
 type Option struct {
 	OvStruct
-	Name  string `xml:"name"`
-	Type  string `xml:"type"`
-	Value string `xml:"value"`
+	Name  *string `xml:"name"`
+	Type  *string `xml:"type"`
+	Value *string `xml:"value"`
 }
 
 type Packages struct {
@@ -1116,7 +1116,7 @@ type Packages struct {
 
 type Package struct {
 	OvStruct
-	Name string `xml:"name"`
+	Name *string `xml:"name"`
 }
 
 type Payloads struct {
@@ -1128,7 +1128,7 @@ type Payload struct {
 	OvStruct
 	Files    []File       `xml:"files"`
 	Type     VmDeviceType `xml:"type"`
-	VolumeId string       `xml:"volume_id"`
+	VolumeId *string      `xml:"volume_id"`
 }
 
 type Permissions struct {
@@ -1139,14 +1139,14 @@ type Permissions struct {
 type Permission struct {
 	OvStruct
 	Cluster       *Cluster       `xml:"cluster"`
-	Comment       string         `xml:"comment"`
+	Comment       *string        `xml:"comment"`
 	DataCenter    *DataCenter    `xml:"data_center"`
-	Description   string         `xml:"description"`
+	Description   *string        `xml:"description"`
 	Disk          *Disk          `xml:"disk"`
 	Group         *Group         `xml:"group"`
 	Host          *Host          `xml:"host"`
-	Id            string         `xml:"id,attr"`
-	Name          string         `xml:"name"`
+	Id            *string        `xml:"id,attr"`
+	Name          *string        `xml:"name"`
 	Role          *Role          `xml:"role"`
 	StorageDomain *StorageDomain `xml:"storage_domain"`
 	Template      *Template      `xml:"template"`
@@ -1162,12 +1162,12 @@ type Permits struct {
 
 type Permit struct {
 	OvStruct
-	Administrative bool   `xml:"administrative"`
-	Comment        string `xml:"comment"`
-	Description    string `xml:"description"`
-	Id             string `xml:"id,attr"`
-	Name           string `xml:"name"`
-	Role           *Role  `xml:"role"`
+	Administrative *bool   `xml:"administrative"`
+	Comment        *string `xml:"comment"`
+	Description    *string `xml:"description"`
+	Id             *string `xml:"id,attr"`
+	Name           *string `xml:"name"`
+	Role           *Role   `xml:"role"`
 }
 
 type PmProxys struct {
@@ -1196,17 +1196,17 @@ type PowerManagements struct {
 
 type PowerManagement struct {
 	OvStruct
-	Address            string                `xml:"address"`
+	Address            *string               `xml:"address"`
 	Agents             []Agent               `xml:"agents"`
-	AutomaticPmEnabled bool                  `xml:"automatic_pm_enabled"`
-	Enabled            bool                  `xml:"enabled"`
-	KdumpDetection     bool                  `xml:"kdump_detection"`
+	AutomaticPmEnabled *bool                 `xml:"automatic_pm_enabled"`
+	Enabled            *bool                 `xml:"enabled"`
+	KdumpDetection     *bool                 `xml:"kdump_detection"`
 	Options            []Option              `xml:"options"`
-	Password           string                `xml:"password"`
+	Password           *string               `xml:"password"`
 	PmProxies          []PmProxy             `xml:"pm_proxies"`
 	Status             PowerManagementStatus `xml:"status"`
-	Type               string                `xml:"type"`
-	Username           string                `xml:"username"`
+	Type               *string               `xml:"type"`
+	Username           *string               `xml:"username"`
 }
 
 type Products struct {
@@ -1216,10 +1216,10 @@ type Products struct {
 
 type Product struct {
 	OvStruct
-	Comment     string `xml:"comment"`
-	Description string `xml:"description"`
-	Id          string `xml:"id,attr"`
-	Name        string `xml:"name"`
+	Comment     *string `xml:"comment"`
+	Description *string `xml:"description"`
+	Id          *string `xml:"id,attr"`
+	Name        *string `xml:"name"`
 }
 
 type ProductInfos struct {
@@ -1229,8 +1229,8 @@ type ProductInfos struct {
 
 type ProductInfo struct {
 	OvStruct
-	Name    string   `xml:"name"`
-	Vendor  string   `xml:"vendor"`
+	Name    *string  `xml:"name"`
+	Vendor  *string  `xml:"vendor"`
 	Version *Version `xml:"version"`
 }
 
@@ -1242,9 +1242,9 @@ type ProfileDetails struct {
 type ProfileDetail struct {
 	OvStruct
 	BlockStatistics []BlockStatistic `xml:"block_statistics"`
-	Duration        int64            `xml:"duration"`
+	Duration        *int64           `xml:"duration"`
 	FopStatistics   []FopStatistic   `xml:"fop_statistics"`
-	ProfileType     string           `xml:"profile_type"`
+	ProfileType     *string          `xml:"profile_type"`
 	Statistics      []Statistic      `xml:"statistics"`
 }
 
@@ -1255,8 +1255,8 @@ type Propertys struct {
 
 type Property struct {
 	OvStruct
-	Name  string `xml:"name"`
-	Value string `xml:"value"`
+	Name  *string `xml:"name"`
+	Value *string `xml:"value"`
 }
 
 type ProxyTickets struct {
@@ -1266,7 +1266,7 @@ type ProxyTickets struct {
 
 type ProxyTicket struct {
 	OvStruct
-	Value string `xml:"value"`
+	Value *string `xml:"value"`
 }
 
 type Qoss struct {
@@ -1276,27 +1276,27 @@ type Qoss struct {
 
 type Qos struct {
 	OvStruct
-	Comment                   string      `xml:"comment"`
-	CpuLimit                  int64       `xml:"cpu_limit"`
+	Comment                   *string     `xml:"comment"`
+	CpuLimit                  *int64      `xml:"cpu_limit"`
 	DataCenter                *DataCenter `xml:"data_center"`
-	Description               string      `xml:"description"`
-	Id                        string      `xml:"id,attr"`
-	InboundAverage            int64       `xml:"inbound_average"`
-	InboundBurst              int64       `xml:"inbound_burst"`
-	InboundPeak               int64       `xml:"inbound_peak"`
-	MaxIops                   int64       `xml:"max_iops"`
-	MaxReadIops               int64       `xml:"max_read_iops"`
-	MaxReadThroughput         int64       `xml:"max_read_throughput"`
-	MaxThroughput             int64       `xml:"max_throughput"`
-	MaxWriteIops              int64       `xml:"max_write_iops"`
-	MaxWriteThroughput        int64       `xml:"max_write_throughput"`
-	Name                      string      `xml:"name"`
-	OutboundAverage           int64       `xml:"outbound_average"`
-	OutboundAverageLinkshare  int64       `xml:"outbound_average_linkshare"`
-	OutboundAverageRealtime   int64       `xml:"outbound_average_realtime"`
-	OutboundAverageUpperlimit int64       `xml:"outbound_average_upperlimit"`
-	OutboundBurst             int64       `xml:"outbound_burst"`
-	OutboundPeak              int64       `xml:"outbound_peak"`
+	Description               *string     `xml:"description"`
+	Id                        *string     `xml:"id,attr"`
+	InboundAverage            *int64      `xml:"inbound_average"`
+	InboundBurst              *int64      `xml:"inbound_burst"`
+	InboundPeak               *int64      `xml:"inbound_peak"`
+	MaxIops                   *int64      `xml:"max_iops"`
+	MaxReadIops               *int64      `xml:"max_read_iops"`
+	MaxReadThroughput         *int64      `xml:"max_read_throughput"`
+	MaxThroughput             *int64      `xml:"max_throughput"`
+	MaxWriteIops              *int64      `xml:"max_write_iops"`
+	MaxWriteThroughput        *int64      `xml:"max_write_throughput"`
+	Name                      *string     `xml:"name"`
+	OutboundAverage           *int64      `xml:"outbound_average"`
+	OutboundAverageLinkshare  *int64      `xml:"outbound_average_linkshare"`
+	OutboundAverageRealtime   *int64      `xml:"outbound_average_realtime"`
+	OutboundAverageUpperlimit *int64      `xml:"outbound_average_upperlimit"`
+	OutboundBurst             *int64      `xml:"outbound_burst"`
+	OutboundPeak              *int64      `xml:"outbound_peak"`
 	Type                      QosType     `xml:"type"`
 }
 
@@ -1307,19 +1307,19 @@ type Quotas struct {
 
 type Quota struct {
 	OvStruct
-	ClusterHardLimitPct int64               `xml:"cluster_hard_limit_pct"`
-	ClusterSoftLimitPct int64               `xml:"cluster_soft_limit_pct"`
-	Comment             string              `xml:"comment"`
+	ClusterHardLimitPct *int64              `xml:"cluster_hard_limit_pct"`
+	ClusterSoftLimitPct *int64              `xml:"cluster_soft_limit_pct"`
+	Comment             *string             `xml:"comment"`
 	DataCenter          *DataCenter         `xml:"data_center"`
-	Description         string              `xml:"description"`
+	Description         *string             `xml:"description"`
 	Disks               []Disk              `xml:"disks"`
-	Id                  string              `xml:"id,attr"`
-	Name                string              `xml:"name"`
+	Id                  *string             `xml:"id,attr"`
+	Name                *string             `xml:"name"`
 	Permissions         []Permission        `xml:"permissions"`
 	QuotaClusterLimits  []QuotaClusterLimit `xml:"quota_cluster_limits"`
 	QuotaStorageLimits  []QuotaStorageLimit `xml:"quota_storage_limits"`
-	StorageHardLimitPct int64               `xml:"storage_hard_limit_pct"`
-	StorageSoftLimitPct int64               `xml:"storage_soft_limit_pct"`
+	StorageHardLimitPct *int64              `xml:"storage_hard_limit_pct"`
+	StorageSoftLimitPct *int64              `xml:"storage_soft_limit_pct"`
 	Users               []User              `xml:"users"`
 	Vms                 []Vm                `xml:"vms"`
 }
@@ -1332,15 +1332,15 @@ type QuotaClusterLimits struct {
 type QuotaClusterLimit struct {
 	OvStruct
 	Cluster     *Cluster `xml:"cluster"`
-	Comment     string   `xml:"comment"`
-	Description string   `xml:"description"`
-	Id          string   `xml:"id,attr"`
-	MemoryLimit float64  `xml:"memory_limit"`
-	MemoryUsage float64  `xml:"memory_usage"`
-	Name        string   `xml:"name"`
+	Comment     *string  `xml:"comment"`
+	Description *string  `xml:"description"`
+	Id          *string  `xml:"id,attr"`
+	MemoryLimit *float64 `xml:"memory_limit"`
+	MemoryUsage *float64 `xml:"memory_usage"`
+	Name        *string  `xml:"name"`
 	Quota       *Quota   `xml:"quota"`
-	VcpuLimit   int64    `xml:"vcpu_limit"`
-	VcpuUsage   int64    `xml:"vcpu_usage"`
+	VcpuLimit   *int64   `xml:"vcpu_limit"`
+	VcpuUsage   *int64   `xml:"vcpu_usage"`
 }
 
 type QuotaStorageLimits struct {
@@ -1350,14 +1350,14 @@ type QuotaStorageLimits struct {
 
 type QuotaStorageLimit struct {
 	OvStruct
-	Comment       string         `xml:"comment"`
-	Description   string         `xml:"description"`
-	Id            string         `xml:"id,attr"`
-	Limit         int64          `xml:"limit"`
-	Name          string         `xml:"name"`
+	Comment       *string        `xml:"comment"`
+	Description   *string        `xml:"description"`
+	Id            *string        `xml:"id,attr"`
+	Limit         *int64         `xml:"limit"`
+	Name          *string        `xml:"name"`
 	Quota         *Quota         `xml:"quota"`
 	StorageDomain *StorageDomain `xml:"storage_domain"`
-	Usage         float64        `xml:"usage"`
+	Usage         *float64       `xml:"usage"`
 }
 
 type Ranges struct {
@@ -1367,8 +1367,8 @@ type Ranges struct {
 
 type Range struct {
 	OvStruct
-	From string `xml:"from"`
-	To   string `xml:"to"`
+	From *string `xml:"from"`
+	To   *string `xml:"to"`
 }
 
 type Rates struct {
@@ -1378,8 +1378,8 @@ type Rates struct {
 
 type Rate struct {
 	OvStruct
-	Bytes  int64 `xml:"bytes"`
-	Period int64 `xml:"period"`
+	Bytes  *int64 `xml:"bytes"`
+	Period *int64 `xml:"period"`
 }
 
 type ReportedConfigurations struct {
@@ -1389,10 +1389,10 @@ type ReportedConfigurations struct {
 
 type ReportedConfiguration struct {
 	OvStruct
-	ActualValue   string `xml:"actual_value"`
-	ExpectedValue string `xml:"expected_value"`
-	InSync        bool   `xml:"in_sync"`
-	Name          string `xml:"name"`
+	ActualValue   *string `xml:"actual_value"`
+	ExpectedValue *string `xml:"expected_value"`
+	InSync        *bool   `xml:"in_sync"`
+	Name          *string `xml:"name"`
 }
 
 type ReportedDevices struct {
@@ -1402,12 +1402,12 @@ type ReportedDevices struct {
 
 type ReportedDevice struct {
 	OvStruct
-	Comment     string             `xml:"comment"`
-	Description string             `xml:"description"`
-	Id          string             `xml:"id,attr"`
+	Comment     *string            `xml:"comment"`
+	Description *string            `xml:"description"`
+	Id          *string            `xml:"id,attr"`
 	Ips         []Ip               `xml:"ips"`
 	Mac         *Mac               `xml:"mac"`
-	Name        string             `xml:"name"`
+	Name        *string            `xml:"name"`
 	Type        ReportedDeviceType `xml:"type"`
 	Vm          *Vm                `xml:"vm"`
 }
@@ -1430,12 +1430,12 @@ type Roles struct {
 
 type Role struct {
 	OvStruct
-	Administrative bool     `xml:"administrative"`
-	Comment        string   `xml:"comment"`
-	Description    string   `xml:"description"`
-	Id             string   `xml:"id,attr"`
-	Mutable        bool     `xml:"mutable"`
-	Name           string   `xml:"name"`
+	Administrative *bool    `xml:"administrative"`
+	Comment        *string  `xml:"comment"`
+	Description    *string  `xml:"description"`
+	Id             *string  `xml:"id,attr"`
+	Mutable        *bool    `xml:"mutable"`
+	Name           *string  `xml:"name"`
 	Permits        []Permit `xml:"permits"`
 	User           *User    `xml:"user"`
 }
@@ -1448,13 +1448,13 @@ type SchedulingPolicys struct {
 type SchedulingPolicy struct {
 	OvStruct
 	Balances      []Balance  `xml:"balances"`
-	Comment       string     `xml:"comment"`
-	DefaultPolicy bool       `xml:"default_policy"`
-	Description   string     `xml:"description"`
+	Comment       *string    `xml:"comment"`
+	DefaultPolicy *bool      `xml:"default_policy"`
+	Description   *string    `xml:"description"`
 	Filters       []Filter   `xml:"filters"`
-	Id            string     `xml:"id,attr"`
-	Locked        bool       `xml:"locked"`
-	Name          string     `xml:"name"`
+	Id            *string    `xml:"id,attr"`
+	Locked        *bool      `xml:"locked"`
+	Name          *string    `xml:"name"`
 	Properties    []Property `xml:"properties"`
 	Weight        []Weight   `xml:"weight"`
 }
@@ -1466,12 +1466,12 @@ type SchedulingPolicyUnits struct {
 
 type SchedulingPolicyUnit struct {
 	OvStruct
-	Comment     string         `xml:"comment"`
-	Description string         `xml:"description"`
-	Enabled     bool           `xml:"enabled"`
-	Id          string         `xml:"id,attr"`
-	Internal    bool           `xml:"internal"`
-	Name        string         `xml:"name"`
+	Comment     *string        `xml:"comment"`
+	Description *string        `xml:"description"`
+	Enabled     *bool          `xml:"enabled"`
+	Id          *string        `xml:"id,attr"`
+	Internal    *bool          `xml:"internal"`
+	Name        *string        `xml:"name"`
 	Properties  []Property     `xml:"properties"`
 	Type        PolicyUnitType `xml:"type"`
 }
@@ -1494,7 +1494,7 @@ type SerialNumbers struct {
 type SerialNumber struct {
 	OvStruct
 	Policy SerialNumberPolicy `xml:"policy"`
-	Value  string             `xml:"value"`
+	Value  *string            `xml:"value"`
 }
 
 type Sessions struct {
@@ -1504,15 +1504,15 @@ type Sessions struct {
 
 type Session struct {
 	OvStruct
-	Comment     string `xml:"comment"`
-	ConsoleUser bool   `xml:"console_user"`
-	Description string `xml:"description"`
-	Id          string `xml:"id,attr"`
-	Ip          *Ip    `xml:"ip"`
-	Name        string `xml:"name"`
-	Protocol    string `xml:"protocol"`
-	User        *User  `xml:"user"`
-	Vm          *Vm    `xml:"vm"`
+	Comment     *string `xml:"comment"`
+	ConsoleUser *bool   `xml:"console_user"`
+	Description *string `xml:"description"`
+	Id          *string `xml:"id,attr"`
+	Ip          *Ip     `xml:"ip"`
+	Name        *string `xml:"name"`
+	Protocol    *string `xml:"protocol"`
+	User        *User   `xml:"user"`
+	Vm          *Vm     `xml:"vm"`
 }
 
 type SkipIfConnectivityBrokens struct {
@@ -1522,8 +1522,8 @@ type SkipIfConnectivityBrokens struct {
 
 type SkipIfConnectivityBroken struct {
 	OvStruct
-	Enabled   bool  `xml:"enabled"`
-	Threshold int64 `xml:"threshold"`
+	Enabled   *bool  `xml:"enabled"`
+	Threshold *int64 `xml:"threshold"`
 }
 
 type SkipIfSdActives struct {
@@ -1533,7 +1533,7 @@ type SkipIfSdActives struct {
 
 type SkipIfSdActive struct {
 	OvStruct
-	Enabled bool `xml:"enabled"`
+	Enabled *bool `xml:"enabled"`
 }
 
 type SpecialObjectss struct {
@@ -1554,7 +1554,7 @@ type Spms struct {
 
 type Spm struct {
 	OvStruct
-	Priority int64     `xml:"priority"`
+	Priority *int64    `xml:"priority"`
 	Status   SpmStatus `xml:"status"`
 }
 
@@ -1566,12 +1566,12 @@ type Sshs struct {
 type Ssh struct {
 	OvStruct
 	AuthenticationMethod SshAuthenticationMethod `xml:"authentication_method"`
-	Comment              string                  `xml:"comment"`
-	Description          string                  `xml:"description"`
-	Fingerprint          string                  `xml:"fingerprint"`
-	Id                   string                  `xml:"id,attr"`
-	Name                 string                  `xml:"name"`
-	Port                 int64                   `xml:"port"`
+	Comment              *string                 `xml:"comment"`
+	Description          *string                 `xml:"description"`
+	Fingerprint          *string                 `xml:"fingerprint"`
+	Id                   *string                 `xml:"id,attr"`
+	Name                 *string                 `xml:"name"`
+	Port                 *int64                  `xml:"port"`
 	User                 *User                   `xml:"user"`
 }
 
@@ -1582,12 +1582,12 @@ type SshPublicKeys struct {
 
 type SshPublicKey struct {
 	OvStruct
-	Comment     string `xml:"comment"`
-	Content     string `xml:"content"`
-	Description string `xml:"description"`
-	Id          string `xml:"id,attr"`
-	Name        string `xml:"name"`
-	User        *User  `xml:"user"`
+	Comment     *string `xml:"comment"`
+	Content     *string `xml:"content"`
+	Description *string `xml:"description"`
+	Id          *string `xml:"id,attr"`
+	Name        *string `xml:"name"`
+	User        *User   `xml:"user"`
 }
 
 type Ssos struct {
@@ -1608,16 +1608,16 @@ type Statistics struct {
 type Statistic struct {
 	OvStruct
 	Brick         *GlusterBrick  `xml:"brick"`
-	Comment       string         `xml:"comment"`
-	Description   string         `xml:"description"`
+	Comment       *string        `xml:"comment"`
+	Description   *string        `xml:"description"`
 	Disk          *Disk          `xml:"disk"`
 	GlusterVolume *GlusterVolume `xml:"gluster_volume"`
 	Host          *Host          `xml:"host"`
 	HostNic       *HostNic       `xml:"host_nic"`
 	HostNumaNode  *NumaNode      `xml:"host_numa_node"`
-	Id            string         `xml:"id,attr"`
+	Id            *string        `xml:"id,attr"`
 	Kind          StatisticKind  `xml:"kind"`
-	Name          string         `xml:"name"`
+	Name          *string        `xml:"name"`
 	Nic           *Nic           `xml:"nic"`
 	Step          *Step          `xml:"step"`
 	Type          ValueType      `xml:"type"`
@@ -1633,18 +1633,18 @@ type Steps struct {
 
 type Step struct {
 	OvStruct
-	Comment       string             `xml:"comment"`
-	Description   string             `xml:"description"`
+	Comment       *string            `xml:"comment"`
+	Description   *string            `xml:"description"`
 	EndTime       time.Time          `xml:"end_time"`
 	ExecutionHost *Host              `xml:"execution_host"`
-	External      bool               `xml:"external"`
+	External      *bool              `xml:"external"`
 	ExternalType  ExternalSystemType `xml:"external_type"`
-	Id            string             `xml:"id,attr"`
+	Id            *string            `xml:"id,attr"`
 	Job           *Job               `xml:"job"`
-	Name          string             `xml:"name"`
-	Number        int64              `xml:"number"`
+	Name          *string            `xml:"name"`
+	Number        *int64             `xml:"number"`
 	ParentStep    *Step              `xml:"parent_step"`
-	Progress      int64              `xml:"progress"`
+	Progress      *int64             `xml:"progress"`
 	StartTime     time.Time          `xml:"start_time"`
 	Statistics    []Statistic        `xml:"statistics"`
 	Status        StepStatus         `xml:"status"`
@@ -1658,24 +1658,24 @@ type StorageConnections struct {
 
 type StorageConnection struct {
 	OvStruct
-	Address      string      `xml:"address"`
-	Comment      string      `xml:"comment"`
-	Description  string      `xml:"description"`
+	Address      *string     `xml:"address"`
+	Comment      *string     `xml:"comment"`
+	Description  *string     `xml:"description"`
 	Host         *Host       `xml:"host"`
-	Id           string      `xml:"id,attr"`
-	MountOptions string      `xml:"mount_options"`
-	Name         string      `xml:"name"`
-	NfsRetrans   int64       `xml:"nfs_retrans"`
-	NfsTimeo     int64       `xml:"nfs_timeo"`
+	Id           *string     `xml:"id,attr"`
+	MountOptions *string     `xml:"mount_options"`
+	Name         *string     `xml:"name"`
+	NfsRetrans   *int64      `xml:"nfs_retrans"`
+	NfsTimeo     *int64      `xml:"nfs_timeo"`
 	NfsVersion   NfsVersion  `xml:"nfs_version"`
-	Password     string      `xml:"password"`
-	Path         string      `xml:"path"`
-	Port         int64       `xml:"port"`
-	Portal       string      `xml:"portal"`
-	Target       string      `xml:"target"`
+	Password     *string     `xml:"password"`
+	Path         *string     `xml:"path"`
+	Port         *int64      `xml:"port"`
+	Portal       *string     `xml:"portal"`
+	Target       *string     `xml:"target"`
 	Type         StorageType `xml:"type"`
-	Username     string      `xml:"username"`
-	VfsType      string      `xml:"vfs_type"`
+	Username     *string     `xml:"username"`
+	VfsType      *string     `xml:"vfs_type"`
 }
 
 type StorageConnectionExtensions struct {
@@ -1685,14 +1685,14 @@ type StorageConnectionExtensions struct {
 
 type StorageConnectionExtension struct {
 	OvStruct
-	Comment     string `xml:"comment"`
-	Description string `xml:"description"`
-	Host        *Host  `xml:"host"`
-	Id          string `xml:"id,attr"`
-	Name        string `xml:"name"`
-	Password    string `xml:"password"`
-	Target      string `xml:"target"`
-	Username    string `xml:"username"`
+	Comment     *string `xml:"comment"`
+	Description *string `xml:"description"`
+	Host        *Host   `xml:"host"`
+	Id          *string `xml:"id,attr"`
+	Name        *string `xml:"name"`
+	Password    *string `xml:"password"`
+	Target      *string `xml:"target"`
+	Username    *string `xml:"username"`
 }
 
 type StorageDomains struct {
@@ -1702,38 +1702,38 @@ type StorageDomains struct {
 
 type StorageDomain struct {
 	OvStruct
-	Available                  int64               `xml:"available"`
-	Comment                    string              `xml:"comment"`
-	Committed                  int64               `xml:"committed"`
-	CriticalSpaceActionBlocker int64               `xml:"critical_space_action_blocker"`
+	Available                  *int64              `xml:"available"`
+	Comment                    *string             `xml:"comment"`
+	Committed                  *int64              `xml:"committed"`
+	CriticalSpaceActionBlocker *int64              `xml:"critical_space_action_blocker"`
 	DataCenter                 *DataCenter         `xml:"data_center"`
 	DataCenters                []DataCenter        `xml:"data_centers"`
-	Description                string              `xml:"description"`
-	DiscardAfterDelete         bool                `xml:"discard_after_delete"`
+	Description                *string             `xml:"description"`
+	DiscardAfterDelete         *bool               `xml:"discard_after_delete"`
 	DiskProfiles               []DiskProfile       `xml:"disk_profiles"`
 	DiskSnapshots              []DiskSnapshot      `xml:"disk_snapshots"`
 	Disks                      []Disk              `xml:"disks"`
 	ExternalStatus             ExternalStatus      `xml:"external_status"`
 	Files                      []File              `xml:"files"`
 	Host                       *Host               `xml:"host"`
-	Id                         string              `xml:"id,attr"`
+	Id                         *string             `xml:"id,attr"`
 	Images                     []Image             `xml:"images"`
-	Import                     bool                `xml:"import"`
-	Master                     bool                `xml:"master"`
-	Name                       string              `xml:"name"`
+	Import                     *bool               `xml:"import"`
+	Master                     *bool               `xml:"master"`
+	Name                       *string             `xml:"name"`
 	Permissions                []Permission        `xml:"permissions"`
 	Status                     StorageDomainStatus `xml:"status"`
 	Storage                    *HostStorage        `xml:"storage"`
 	StorageConnections         []StorageConnection `xml:"storage_connections"`
 	StorageFormat              StorageFormat       `xml:"storage_format"`
-	SupportsDiscard            bool                `xml:"supports_discard"`
-	SupportsDiscardZeroesData  bool                `xml:"supports_discard_zeroes_data"`
+	SupportsDiscard            *bool               `xml:"supports_discard"`
+	SupportsDiscardZeroesData  *bool               `xml:"supports_discard_zeroes_data"`
 	Templates                  []Template          `xml:"templates"`
 	Type                       StorageDomainType   `xml:"type"`
-	Used                       int64               `xml:"used"`
+	Used                       *int64              `xml:"used"`
 	Vms                        []Vm                `xml:"vms"`
-	WarningLowSpaceIndicator   int64               `xml:"warning_low_space_indicator"`
-	WipeAfterDelete            bool                `xml:"wipe_after_delete"`
+	WarningLowSpaceIndicator   *int64              `xml:"warning_low_space_indicator"`
+	WipeAfterDelete            *bool               `xml:"wipe_after_delete"`
 }
 
 type StorageDomainLeases struct {
@@ -1753,12 +1753,12 @@ type Tags struct {
 
 type Tag struct {
 	OvStruct
-	Comment     string    `xml:"comment"`
-	Description string    `xml:"description"`
+	Comment     *string   `xml:"comment"`
+	Description *string   `xml:"description"`
 	Group       *Group    `xml:"group"`
 	Host        *Host     `xml:"host"`
-	Id          string    `xml:"id,attr"`
-	Name        string    `xml:"name"`
+	Id          *string   `xml:"id,attr"`
+	Name        *string   `xml:"name"`
 	Parent      *Tag      `xml:"parent"`
 	Template    *Template `xml:"template"`
 	User        *User     `xml:"user"`
@@ -1773,8 +1773,8 @@ type TemplateVersions struct {
 type TemplateVersion struct {
 	OvStruct
 	BaseTemplate  *Template `xml:"base_template"`
-	VersionName   string    `xml:"version_name"`
-	VersionNumber int64     `xml:"version_number"`
+	VersionName   *string   `xml:"version_name"`
+	VersionNumber *int64    `xml:"version_number"`
 }
 
 type Tickets struct {
@@ -1784,8 +1784,8 @@ type Tickets struct {
 
 type Ticket struct {
 	OvStruct
-	Expiry int64  `xml:"expiry"`
-	Value  string `xml:"value"`
+	Expiry *int64  `xml:"expiry"`
+	Value  *string `xml:"value"`
 }
 
 type TimeZones struct {
@@ -1795,8 +1795,8 @@ type TimeZones struct {
 
 type TimeZone struct {
 	OvStruct
-	Name      string `xml:"name"`
-	UtcOffset string `xml:"utc_offset"`
+	Name      *string `xml:"name"`
+	UtcOffset *string `xml:"utc_offset"`
 }
 
 type TransparentHugePagess struct {
@@ -1806,7 +1806,7 @@ type TransparentHugePagess struct {
 
 type TransparentHugePages struct {
 	OvStruct
-	Enabled bool `xml:"enabled"`
+	Enabled *bool `xml:"enabled"`
 }
 
 type UnmanagedNetworks struct {
@@ -1816,12 +1816,12 @@ type UnmanagedNetworks struct {
 
 type UnmanagedNetwork struct {
 	OvStruct
-	Comment     string   `xml:"comment"`
-	Description string   `xml:"description"`
+	Comment     *string  `xml:"comment"`
+	Description *string  `xml:"description"`
 	Host        *Host    `xml:"host"`
 	HostNic     *HostNic `xml:"host_nic"`
-	Id          string   `xml:"id,attr"`
-	Name        string   `xml:"name"`
+	Id          *string  `xml:"id,attr"`
+	Name        *string  `xml:"name"`
 }
 
 type Usbs struct {
@@ -1831,7 +1831,7 @@ type Usbs struct {
 
 type Usb struct {
 	OvStruct
-	Enabled bool    `xml:"enabled"`
+	Enabled *bool   `xml:"enabled"`
 	Type    UsbType `xml:"type"`
 }
 
@@ -1842,25 +1842,25 @@ type Users struct {
 
 type User struct {
 	OvStruct
-	Comment       string         `xml:"comment"`
-	Department    string         `xml:"department"`
-	Description   string         `xml:"description"`
+	Comment       *string        `xml:"comment"`
+	Department    *string        `xml:"department"`
+	Description   *string        `xml:"description"`
 	Domain        *Domain        `xml:"domain"`
-	DomainEntryId string         `xml:"domain_entry_id"`
-	Email         string         `xml:"email"`
+	DomainEntryId *string        `xml:"domain_entry_id"`
+	Email         *string        `xml:"email"`
 	Groups        []Group        `xml:"groups"`
-	Id            string         `xml:"id,attr"`
-	LastName      string         `xml:"last_name"`
-	LoggedIn      bool           `xml:"logged_in"`
-	Name          string         `xml:"name"`
-	Namespace     string         `xml:"namespace"`
-	Password      string         `xml:"password"`
+	Id            *string        `xml:"id,attr"`
+	LastName      *string        `xml:"last_name"`
+	LoggedIn      *bool          `xml:"logged_in"`
+	Name          *string        `xml:"name"`
+	Namespace     *string        `xml:"namespace"`
+	Password      *string        `xml:"password"`
 	Permissions   []Permission   `xml:"permissions"`
-	Principal     string         `xml:"principal"`
+	Principal     *string        `xml:"principal"`
 	Roles         []Role         `xml:"roles"`
 	SshPublicKeys []SshPublicKey `xml:"ssh_public_keys"`
 	Tags          []Tag          `xml:"tags"`
-	UserName      string         `xml:"user_name"`
+	UserName      *string        `xml:"user_name"`
 }
 
 type Values struct {
@@ -1870,8 +1870,8 @@ type Values struct {
 
 type Value struct {
 	OvStruct
-	Datum  float64 `xml:"datum"`
-	Detail string  `xml:"detail"`
+	Datum  *float64 `xml:"datum"`
+	Detail *string  `xml:"detail"`
 }
 
 type VcpuPins struct {
@@ -1881,8 +1881,8 @@ type VcpuPins struct {
 
 type VcpuPin struct {
 	OvStruct
-	CpuSet string `xml:"cpu_set"`
-	Vcpu   int64  `xml:"vcpu"`
+	CpuSet *string `xml:"cpu_set"`
+	Vcpu   *int64  `xml:"vcpu"`
 }
 
 type Vendors struct {
@@ -1892,10 +1892,10 @@ type Vendors struct {
 
 type Vendor struct {
 	OvStruct
-	Comment     string `xml:"comment"`
-	Description string `xml:"description"`
-	Id          string `xml:"id,attr"`
-	Name        string `xml:"name"`
+	Comment     *string `xml:"comment"`
+	Description *string `xml:"description"`
+	Id          *string `xml:"id,attr"`
+	Name        *string `xml:"name"`
 }
 
 type Versions struct {
@@ -1905,15 +1905,15 @@ type Versions struct {
 
 type Version struct {
 	OvStruct
-	Build       int64  `xml:"build"`
-	Comment     string `xml:"comment"`
-	Description string `xml:"description"`
-	FullVersion string `xml:"full_version"`
-	Id          string `xml:"id,attr"`
-	Major       int64  `xml:"major"`
-	Minor       int64  `xml:"minor"`
-	Name        string `xml:"name"`
-	Revision    int64  `xml:"revision"`
+	Build       *int64  `xml:"build"`
+	Comment     *string `xml:"comment"`
+	Description *string `xml:"description"`
+	FullVersion *string `xml:"full_version"`
+	Id          *string `xml:"id,attr"`
+	Major       *int64  `xml:"major"`
+	Minor       *int64  `xml:"minor"`
+	Name        *string `xml:"name"`
+	Revision    *int64  `xml:"revision"`
 }
 
 type VirtioScsis struct {
@@ -1923,7 +1923,7 @@ type VirtioScsis struct {
 
 type VirtioScsi struct {
 	OvStruct
-	Enabled bool `xml:"enabled"`
+	Enabled *bool `xml:"enabled"`
 }
 
 type VirtualNumaNodes struct {
@@ -1933,15 +1933,15 @@ type VirtualNumaNodes struct {
 
 type VirtualNumaNode struct {
 	OvStruct
-	Comment      string        `xml:"comment"`
+	Comment      *string       `xml:"comment"`
 	Cpu          *Cpu          `xml:"cpu"`
-	Description  string        `xml:"description"`
+	Description  *string       `xml:"description"`
 	Host         *Host         `xml:"host"`
-	Id           string        `xml:"id,attr"`
-	Index        int64         `xml:"index"`
-	Memory       int64         `xml:"memory"`
-	Name         string        `xml:"name"`
-	NodeDistance string        `xml:"node_distance"`
+	Id           *string       `xml:"id,attr"`
+	Index        *int64        `xml:"index"`
+	Memory       *int64        `xml:"memory"`
+	Name         *string       `xml:"name"`
+	NodeDistance *string       `xml:"node_distance"`
 	NumaNodePins []NumaNodePin `xml:"numa_node_pins"`
 	Statistics   []Statistic   `xml:"statistics"`
 	Vm           *Vm           `xml:"vm"`
@@ -1954,7 +1954,7 @@ type Vlans struct {
 
 type Vlan struct {
 	OvStruct
-	Id int64 `xml:"id,attr"`
+	Id *int64 `xml:"id,attr"`
 }
 
 type VmBases struct {
@@ -1966,44 +1966,44 @@ type VmBase struct {
 	OvStruct
 	Bios                       *Bios               `xml:"bios"`
 	Cluster                    *Cluster            `xml:"cluster"`
-	Comment                    string              `xml:"comment"`
+	Comment                    *string             `xml:"comment"`
 	Console                    *Console            `xml:"console"`
 	Cpu                        *Cpu                `xml:"cpu"`
 	CpuProfile                 *CpuProfile         `xml:"cpu_profile"`
-	CpuShares                  int64               `xml:"cpu_shares"`
+	CpuShares                  *int64              `xml:"cpu_shares"`
 	CreationTime               time.Time           `xml:"creation_time"`
 	CustomCompatibilityVersion *Version            `xml:"custom_compatibility_version"`
-	CustomCpuModel             string              `xml:"custom_cpu_model"`
-	CustomEmulatedMachine      string              `xml:"custom_emulated_machine"`
+	CustomCpuModel             *string             `xml:"custom_cpu_model"`
+	CustomEmulatedMachine      *string             `xml:"custom_emulated_machine"`
 	CustomProperties           []CustomProperty    `xml:"custom_properties"`
-	DeleteProtected            bool                `xml:"delete_protected"`
-	Description                string              `xml:"description"`
+	DeleteProtected            *bool               `xml:"delete_protected"`
+	Description                *string             `xml:"description"`
 	Display                    *Display            `xml:"display"`
 	Domain                     *Domain             `xml:"domain"`
 	HighAvailability           *HighAvailability   `xml:"high_availability"`
-	Id                         string              `xml:"id,attr"`
+	Id                         *string             `xml:"id,attr"`
 	Initialization             *Initialization     `xml:"initialization"`
 	Io                         *Io                 `xml:"io"`
 	LargeIcon                  *Icon               `xml:"large_icon"`
 	Lease                      *StorageDomainLease `xml:"lease"`
-	Memory                     int64               `xml:"memory"`
+	Memory                     *int64              `xml:"memory"`
 	MemoryPolicy               *MemoryPolicy       `xml:"memory_policy"`
 	Migration                  *MigrationOptions   `xml:"migration"`
-	MigrationDowntime          int64               `xml:"migration_downtime"`
-	Name                       string              `xml:"name"`
-	Origin                     string              `xml:"origin"`
+	MigrationDowntime          *int64              `xml:"migration_downtime"`
+	Name                       *string             `xml:"name"`
+	Origin                     *string             `xml:"origin"`
 	Os                         *OperatingSystem    `xml:"os"`
 	Quota                      *Quota              `xml:"quota"`
 	RngDevice                  *RngDevice          `xml:"rng_device"`
 	SerialNumber               *SerialNumber       `xml:"serial_number"`
 	SmallIcon                  *Icon               `xml:"small_icon"`
-	SoundcardEnabled           bool                `xml:"soundcard_enabled"`
+	SoundcardEnabled           *bool               `xml:"soundcard_enabled"`
 	Sso                        *Sso                `xml:"sso"`
-	StartPaused                bool                `xml:"start_paused"`
-	Stateless                  bool                `xml:"stateless"`
+	StartPaused                *bool               `xml:"start_paused"`
+	Stateless                  *bool               `xml:"stateless"`
 	StorageDomain              *StorageDomain      `xml:"storage_domain"`
 	TimeZone                   *TimeZone           `xml:"time_zone"`
-	TunnelMigration            bool                `xml:"tunnel_migration"`
+	TunnelMigration            *bool               `xml:"tunnel_migration"`
 	Type                       VmType              `xml:"type"`
 	Usb                        *Usb                `xml:"usb"`
 	VirtioScsi                 *VirtioScsi         `xml:"virtio_scsi"`
@@ -2027,24 +2027,24 @@ type VmPools struct {
 
 type VmPool struct {
 	OvStruct
-	AutoStorageSelect        bool          `xml:"auto_storage_select"`
+	AutoStorageSelect        *bool         `xml:"auto_storage_select"`
 	Cluster                  *Cluster      `xml:"cluster"`
-	Comment                  string        `xml:"comment"`
-	Description              string        `xml:"description"`
+	Comment                  *string       `xml:"comment"`
+	Description              *string       `xml:"description"`
 	Display                  *Display      `xml:"display"`
-	Id                       string        `xml:"id,attr"`
+	Id                       *string       `xml:"id,attr"`
 	InstanceType             *InstanceType `xml:"instance_type"`
-	MaxUserVms               int64         `xml:"max_user_vms"`
-	Name                     string        `xml:"name"`
+	MaxUserVms               *int64        `xml:"max_user_vms"`
+	Name                     *string       `xml:"name"`
 	Permissions              []Permission  `xml:"permissions"`
-	PrestartedVms            int64         `xml:"prestarted_vms"`
+	PrestartedVms            *int64        `xml:"prestarted_vms"`
 	RngDevice                *RngDevice    `xml:"rng_device"`
-	Size                     int64         `xml:"size"`
-	SoundcardEnabled         bool          `xml:"soundcard_enabled"`
-	Stateful                 bool          `xml:"stateful"`
+	Size                     *int64        `xml:"size"`
+	SoundcardEnabled         *bool         `xml:"soundcard_enabled"`
+	Stateful                 *bool         `xml:"stateful"`
 	Template                 *Template     `xml:"template"`
 	Type                     VmPoolType    `xml:"type"`
-	UseLatestTemplateVersion bool          `xml:"use_latest_template_version"`
+	UseLatestTemplateVersion *bool         `xml:"use_latest_template_version"`
 	Vm                       *Vm           `xml:"vm"`
 }
 
@@ -2055,9 +2055,9 @@ type VmSummarys struct {
 
 type VmSummary struct {
 	OvStruct
-	Active    int64 `xml:"active"`
-	Migrating int64 `xml:"migrating"`
-	Total     int64 `xml:"total"`
+	Active    *int64 `xml:"active"`
+	Migrating *int64 `xml:"migrating"`
+	Total     *int64 `xml:"total"`
 }
 
 type VnicPassThroughs struct {
@@ -2077,17 +2077,17 @@ type VnicProfiles struct {
 
 type VnicProfile struct {
 	OvStruct
-	Comment          string           `xml:"comment"`
+	Comment          *string          `xml:"comment"`
 	CustomProperties []CustomProperty `xml:"custom_properties"`
-	Description      string           `xml:"description"`
-	Id               string           `xml:"id,attr"`
-	Migratable       bool             `xml:"migratable"`
-	Name             string           `xml:"name"`
+	Description      *string          `xml:"description"`
+	Id               *string          `xml:"id,attr"`
+	Migratable       *bool            `xml:"migratable"`
+	Name             *string          `xml:"name"`
 	Network          *Network         `xml:"network"`
 	NetworkFilter    *NetworkFilter   `xml:"network_filter"`
 	PassThrough      *VnicPassThrough `xml:"pass_through"`
 	Permissions      []Permission     `xml:"permissions"`
-	PortMirroring    bool             `xml:"port_mirroring"`
+	PortMirroring    *bool            `xml:"port_mirroring"`
 	Qos              *Qos             `xml:"qos"`
 }
 
@@ -2098,8 +2098,8 @@ type VnicProfileMappings struct {
 
 type VnicProfileMapping struct {
 	OvStruct
-	SourceNetworkName        string       `xml:"source_network_name"`
-	SourceNetworkProfileName string       `xml:"source_network_profile_name"`
+	SourceNetworkName        *string      `xml:"source_network_name"`
+	SourceNetworkProfileName *string      `xml:"source_network_profile_name"`
 	TargetVnicProfile        *VnicProfile `xml:"target_vnic_profile"`
 }
 
@@ -2110,9 +2110,9 @@ type VolumeGroups struct {
 
 type VolumeGroup struct {
 	OvStruct
-	Id           string        `xml:"id,attr"`
+	Id           *string       `xml:"id,attr"`
 	LogicalUnits []LogicalUnit `xml:"logical_units"`
-	Name         string        `xml:"name"`
+	Name         *string       `xml:"name"`
 }
 
 type Weights struct {
@@ -2122,11 +2122,11 @@ type Weights struct {
 
 type Weight struct {
 	OvStruct
-	Comment              string                `xml:"comment"`
-	Description          string                `xml:"description"`
-	Factor               int64                 `xml:"factor"`
-	Id                   string                `xml:"id,attr"`
-	Name                 string                `xml:"name"`
+	Comment              *string               `xml:"comment"`
+	Description          *string               `xml:"description"`
+	Factor               *int64                `xml:"factor"`
+	Id                   *string               `xml:"id,attr"`
+	Name                 *string               `xml:"name"`
 	SchedulingPolicy     *SchedulingPolicy     `xml:"scheduling_policy"`
 	SchedulingPolicyUnit *SchedulingPolicyUnit `xml:"scheduling_policy_unit"`
 }
@@ -2138,70 +2138,70 @@ type Actions struct {
 
 type Action struct {
 	OvStruct
-	AllowPartialImport             bool                                  `xml:"allow_partial_import"`
-	Async                          bool                                  `xml:"async"`
+	AllowPartialImport             *bool                                 `xml:"allow_partial_import"`
+	Async                          *bool                                 `xml:"async"`
 	Bricks                         []GlusterBrick                        `xml:"bricks"`
 	Certificates                   []Certificate                         `xml:"certificates"`
-	CheckConnectivity              bool                                  `xml:"check_connectivity"`
-	Clone                          bool                                  `xml:"clone"`
+	CheckConnectivity              *bool                                 `xml:"check_connectivity"`
+	Clone                          *bool                                 `xml:"clone"`
 	Cluster                        *Cluster                              `xml:"cluster"`
-	CollapseSnapshots              bool                                  `xml:"collapse_snapshots"`
-	Comment                        string                                `xml:"comment"`
-	ConnectivityTimeout            int64                                 `xml:"connectivity_timeout"`
+	CollapseSnapshots              *bool                                 `xml:"collapse_snapshots"`
+	Comment                        *string                               `xml:"comment"`
+	ConnectivityTimeout            *int64                                `xml:"connectivity_timeout"`
 	DataCenter                     *DataCenter                           `xml:"data_center"`
-	DeployHostedEngine             bool                                  `xml:"deploy_hosted_engine"`
-	Description                    string                                `xml:"description"`
+	DeployHostedEngine             *bool                                 `xml:"deploy_hosted_engine"`
+	Description                    *string                               `xml:"description"`
 	Details                        *GlusterVolumeProfileDetails          `xml:"details"`
-	DiscardSnapshots               bool                                  `xml:"discard_snapshots"`
+	DiscardSnapshots               *bool                                 `xml:"discard_snapshots"`
 	Disk                           *Disk                                 `xml:"disk"`
 	Disks                          []Disk                                `xml:"disks"`
-	Exclusive                      bool                                  `xml:"exclusive"`
+	Exclusive                      *bool                                 `xml:"exclusive"`
 	Fault                          *Fault                                `xml:"fault"`
-	FenceType                      string                                `xml:"fence_type"`
-	Filter                         bool                                  `xml:"filter"`
-	FixLayout                      bool                                  `xml:"fix_layout"`
-	Force                          bool                                  `xml:"force"`
+	FenceType                      *string                               `xml:"fence_type"`
+	Filter                         *bool                                 `xml:"filter"`
+	FixLayout                      *bool                                 `xml:"fix_layout"`
+	Force                          *bool                                 `xml:"force"`
 	GracePeriod                    *GracePeriod                          `xml:"grace_period"`
 	Host                           *Host                                 `xml:"host"`
-	Id                             string                                `xml:"id,attr"`
-	Image                          string                                `xml:"image"`
-	ImportAsTemplate               bool                                  `xml:"import_as_template"`
-	IsAttached                     bool                                  `xml:"is_attached"`
+	Id                             *string                               `xml:"id,attr"`
+	Image                          *string                               `xml:"image"`
+	ImportAsTemplate               *bool                                 `xml:"import_as_template"`
+	IsAttached                     *bool                                 `xml:"is_attached"`
 	Iscsi                          *IscsiDetails                         `xml:"iscsi"`
 	IscsiTargets                   []string                              `xml:"iscsi_targets"`
 	Job                            *Job                                  `xml:"job"`
 	LogicalUnits                   []LogicalUnit                         `xml:"logical_units"`
-	MaintenanceEnabled             bool                                  `xml:"maintenance_enabled"`
+	MaintenanceEnabled             *bool                                 `xml:"maintenance_enabled"`
 	ModifiedBonds                  []HostNic                             `xml:"modified_bonds"`
 	ModifiedLabels                 []NetworkLabel                        `xml:"modified_labels"`
 	ModifiedNetworkAttachments     []NetworkAttachment                   `xml:"modified_network_attachments"`
-	Name                           string                                `xml:"name"`
+	Name                           *string                               `xml:"name"`
 	Option                         *Option                               `xml:"option"`
-	Pause                          bool                                  `xml:"pause"`
+	Pause                          *bool                                 `xml:"pause"`
 	PowerManagement                *PowerManagement                      `xml:"power_management"`
 	ProxyTicket                    *ProxyTicket                          `xml:"proxy_ticket"`
-	Reason                         string                                `xml:"reason"`
-	ReassignBadMacs                bool                                  `xml:"reassign_bad_macs"`
-	RemoteViewerConnectionFile     string                                `xml:"remote_viewer_connection_file"`
+	Reason                         *string                               `xml:"reason"`
+	ReassignBadMacs                *bool                                 `xml:"reassign_bad_macs"`
+	RemoteViewerConnectionFile     *string                               `xml:"remote_viewer_connection_file"`
 	RemovedBonds                   []HostNic                             `xml:"removed_bonds"`
 	RemovedLabels                  []NetworkLabel                        `xml:"removed_labels"`
 	RemovedNetworkAttachments      []NetworkAttachment                   `xml:"removed_network_attachments"`
-	ResolutionType                 string                                `xml:"resolution_type"`
-	RestoreMemory                  bool                                  `xml:"restore_memory"`
-	RootPassword                   string                                `xml:"root_password"`
+	ResolutionType                 *string                               `xml:"resolution_type"`
+	RestoreMemory                  *bool                                 `xml:"restore_memory"`
+	RootPassword                   *string                               `xml:"root_password"`
 	Snapshot                       *Snapshot                             `xml:"snapshot"`
 	Ssh                            *Ssh                                  `xml:"ssh"`
-	Status                         string                                `xml:"status"`
-	StopGlusterService             bool                                  `xml:"stop_gluster_service"`
+	Status                         *string                               `xml:"status"`
+	StopGlusterService             *bool                                 `xml:"stop_gluster_service"`
 	StorageDomain                  *StorageDomain                        `xml:"storage_domain"`
 	StorageDomains                 []StorageDomain                       `xml:"storage_domains"`
-	Succeeded                      bool                                  `xml:"succeeded"`
+	Succeeded                      *bool                                 `xml:"succeeded"`
 	SynchronizedNetworkAttachments []NetworkAttachment                   `xml:"synchronized_network_attachments"`
 	Template                       *Template                             `xml:"template"`
 	Ticket                         *Ticket                               `xml:"ticket"`
-	UndeployHostedEngine           bool                                  `xml:"undeploy_hosted_engine"`
-	UseCloudInit                   bool                                  `xml:"use_cloud_init"`
-	UseSysprep                     bool                                  `xml:"use_sysprep"`
+	UndeployHostedEngine           *bool                                 `xml:"undeploy_hosted_engine"`
+	UseCloudInit                   *bool                                 `xml:"use_cloud_init"`
+	UseSysprep                     *bool                                 `xml:"use_sysprep"`
 	VirtualFunctionsConfiguration  *HostNicVirtualFunctionsConfiguration `xml:"virtual_functions_configuration"`
 	Vm                             *Vm                                   `xml:"vm"`
 	VnicProfileMappings            []VnicProfileMapping                  `xml:"vnic_profile_mappings"`
@@ -2215,14 +2215,14 @@ type AffinityGroups struct {
 type AffinityGroup struct {
 	OvStruct
 	Cluster     *Cluster      `xml:"cluster"`
-	Comment     string        `xml:"comment"`
-	Description string        `xml:"description"`
-	Enforcing   bool          `xml:"enforcing"`
+	Comment     *string       `xml:"comment"`
+	Description *string       `xml:"description"`
+	Enforcing   *bool         `xml:"enforcing"`
 	Hosts       []Host        `xml:"hosts"`
 	HostsRule   *AffinityRule `xml:"hosts_rule"`
-	Id          string        `xml:"id,attr"`
-	Name        string        `xml:"name"`
-	Positive    bool          `xml:"positive"`
+	Id          *string       `xml:"id,attr"`
+	Name        *string       `xml:"name"`
+	Positive    *bool         `xml:"positive"`
 	Vms         []Vm          `xml:"vms"`
 	VmsRule     *AffinityRule `xml:"vms_rule"`
 }
@@ -2234,13 +2234,13 @@ type AffinityLabels struct {
 
 type AffinityLabel struct {
 	OvStruct
-	Comment     string `xml:"comment"`
-	Description string `xml:"description"`
-	Hosts       []Host `xml:"hosts"`
-	Id          string `xml:"id,attr"`
-	Name        string `xml:"name"`
-	ReadOnly    bool   `xml:"read_only"`
-	Vms         []Vm   `xml:"vms"`
+	Comment     *string `xml:"comment"`
+	Description *string `xml:"description"`
+	Hosts       []Host  `xml:"hosts"`
+	Id          *string `xml:"id,attr"`
+	Name        *string `xml:"name"`
+	ReadOnly    *bool   `xml:"read_only"`
+	Vms         []Vm    `xml:"vms"`
 }
 
 type Agents struct {
@@ -2250,20 +2250,20 @@ type Agents struct {
 
 type Agent struct {
 	OvStruct
-	Address        string   `xml:"address"`
-	Comment        string   `xml:"comment"`
-	Concurrent     bool     `xml:"concurrent"`
-	Description    string   `xml:"description"`
-	EncryptOptions bool     `xml:"encrypt_options"`
+	Address        *string  `xml:"address"`
+	Comment        *string  `xml:"comment"`
+	Concurrent     *bool    `xml:"concurrent"`
+	Description    *string  `xml:"description"`
+	EncryptOptions *bool    `xml:"encrypt_options"`
 	Host           *Host    `xml:"host"`
-	Id             string   `xml:"id,attr"`
-	Name           string   `xml:"name"`
+	Id             *string  `xml:"id,attr"`
+	Name           *string  `xml:"name"`
 	Options        []Option `xml:"options"`
-	Order          int64    `xml:"order"`
-	Password       string   `xml:"password"`
-	Port           int64    `xml:"port"`
-	Type           string   `xml:"type"`
-	Username       string   `xml:"username"`
+	Order          *int64   `xml:"order"`
+	Password       *string  `xml:"password"`
+	Port           *int64   `xml:"port"`
+	Type           *string  `xml:"type"`
+	Username       *string  `xml:"username"`
 }
 
 type Applications struct {
@@ -2273,11 +2273,11 @@ type Applications struct {
 
 type Application struct {
 	OvStruct
-	Comment     string `xml:"comment"`
-	Description string `xml:"description"`
-	Id          string `xml:"id,attr"`
-	Name        string `xml:"name"`
-	Vm          *Vm    `xml:"vm"`
+	Comment     *string `xml:"comment"`
+	Description *string `xml:"description"`
+	Id          *string `xml:"id,attr"`
+	Name        *string `xml:"name"`
+	Vm          *Vm     `xml:"vm"`
 }
 
 type AuthorizedKeys struct {
@@ -2287,12 +2287,12 @@ type AuthorizedKeys struct {
 
 type AuthorizedKey struct {
 	OvStruct
-	Comment     string `xml:"comment"`
-	Description string `xml:"description"`
-	Id          string `xml:"id,attr"`
-	Key         string `xml:"key"`
-	Name        string `xml:"name"`
-	User        *User  `xml:"user"`
+	Comment     *string `xml:"comment"`
+	Description *string `xml:"description"`
+	Id          *string `xml:"id,attr"`
+	Key         *string `xml:"key"`
+	Name        *string `xml:"name"`
+	User        *User   `xml:"user"`
 }
 
 type Balances struct {
@@ -2302,10 +2302,10 @@ type Balances struct {
 
 type Balance struct {
 	OvStruct
-	Comment              string                `xml:"comment"`
-	Description          string                `xml:"description"`
-	Id                   string                `xml:"id,attr"`
-	Name                 string                `xml:"name"`
+	Comment              *string               `xml:"comment"`
+	Description          *string               `xml:"description"`
+	Id                   *string               `xml:"id,attr"`
+	Name                 *string               `xml:"name"`
 	SchedulingPolicy     *SchedulingPolicy     `xml:"scheduling_policy"`
 	SchedulingPolicyUnit *SchedulingPolicyUnit `xml:"scheduling_policy_unit"`
 }
@@ -2317,11 +2317,11 @@ type Bookmarks struct {
 
 type Bookmark struct {
 	OvStruct
-	Comment     string `xml:"comment"`
-	Description string `xml:"description"`
-	Id          string `xml:"id,attr"`
-	Name        string `xml:"name"`
-	Value       string `xml:"value"`
+	Comment     *string `xml:"comment"`
+	Description *string `xml:"description"`
+	Id          *string `xml:"id,attr"`
+	Name        *string `xml:"name"`
+	Value       *string `xml:"value"`
 }
 
 type BrickProfileDetails struct {
@@ -2342,13 +2342,13 @@ type Certificates struct {
 
 type Certificate struct {
 	OvStruct
-	Comment      string `xml:"comment"`
-	Content      string `xml:"content"`
-	Description  string `xml:"description"`
-	Id           string `xml:"id,attr"`
-	Name         string `xml:"name"`
-	Organization string `xml:"organization"`
-	Subject      string `xml:"subject"`
+	Comment      *string `xml:"comment"`
+	Content      *string `xml:"content"`
+	Description  *string `xml:"description"`
+	Id           *string `xml:"id,attr"`
+	Name         *string `xml:"name"`
+	Organization *string `xml:"organization"`
+	Subject      *string `xml:"subject"`
 }
 
 type Clusters struct {
@@ -2359,43 +2359,43 @@ type Clusters struct {
 type Cluster struct {
 	OvStruct
 	AffinityGroups                   []AffinityGroup   `xml:"affinity_groups"`
-	BallooningEnabled                bool              `xml:"ballooning_enabled"`
-	Comment                          string            `xml:"comment"`
+	BallooningEnabled                *bool             `xml:"ballooning_enabled"`
+	Comment                          *string           `xml:"comment"`
 	Cpu                              *Cpu              `xml:"cpu"`
 	CpuProfiles                      []CpuProfile      `xml:"cpu_profiles"`
 	CustomSchedulingPolicyProperties []Property        `xml:"custom_scheduling_policy_properties"`
 	DataCenter                       *DataCenter       `xml:"data_center"`
-	Description                      string            `xml:"description"`
+	Description                      *string           `xml:"description"`
 	Display                          *Display          `xml:"display"`
 	ErrorHandling                    *ErrorHandling    `xml:"error_handling"`
 	FencingPolicy                    *FencingPolicy    `xml:"fencing_policy"`
 	GlusterHooks                     []GlusterHook     `xml:"gluster_hooks"`
-	GlusterService                   bool              `xml:"gluster_service"`
-	GlusterTunedProfile              string            `xml:"gluster_tuned_profile"`
+	GlusterService                   *bool             `xml:"gluster_service"`
+	GlusterTunedProfile              *string           `xml:"gluster_tuned_profile"`
 	GlusterVolumes                   []GlusterVolume   `xml:"gluster_volumes"`
-	HaReservation                    bool              `xml:"ha_reservation"`
-	Id                               string            `xml:"id,attr"`
+	HaReservation                    *bool             `xml:"ha_reservation"`
+	Id                               *string           `xml:"id,attr"`
 	Ksm                              *Ksm              `xml:"ksm"`
 	MacPool                          *MacPool          `xml:"mac_pool"`
-	MaintenanceReasonRequired        bool              `xml:"maintenance_reason_required"`
+	MaintenanceReasonRequired        *bool             `xml:"maintenance_reason_required"`
 	ManagementNetwork                *Network          `xml:"management_network"`
 	MemoryPolicy                     *MemoryPolicy     `xml:"memory_policy"`
 	Migration                        *MigrationOptions `xml:"migration"`
-	Name                             string            `xml:"name"`
+	Name                             *string           `xml:"name"`
 	NetworkFilters                   []NetworkFilter   `xml:"network_filters"`
 	Networks                         []Network         `xml:"networks"`
-	OptionalReason                   bool              `xml:"optional_reason"`
+	OptionalReason                   *bool             `xml:"optional_reason"`
 	Permissions                      []Permission      `xml:"permissions"`
 	RequiredRngSources               []RngSource       `xml:"required_rng_sources"`
 	SchedulingPolicy                 *SchedulingPolicy `xml:"scheduling_policy"`
 	SerialNumber                     *SerialNumber     `xml:"serial_number"`
 	SupportedVersions                []Version         `xml:"supported_versions"`
 	SwitchType                       SwitchType        `xml:"switch_type"`
-	ThreadsAsCores                   bool              `xml:"threads_as_cores"`
-	TrustedService                   bool              `xml:"trusted_service"`
-	TunnelMigration                  bool              `xml:"tunnel_migration"`
+	ThreadsAsCores                   *bool             `xml:"threads_as_cores"`
+	TrustedService                   *bool             `xml:"trusted_service"`
+	TunnelMigration                  *bool             `xml:"tunnel_migration"`
 	Version                          *Version          `xml:"version"`
-	VirtService                      bool              `xml:"virt_service"`
+	VirtService                      *bool             `xml:"virt_service"`
 }
 
 type ClusterLevels struct {
@@ -2405,11 +2405,11 @@ type ClusterLevels struct {
 
 type ClusterLevel struct {
 	OvStruct
-	Comment     string    `xml:"comment"`
+	Comment     *string   `xml:"comment"`
 	CpuTypes    []CpuType `xml:"cpu_types"`
-	Description string    `xml:"description"`
-	Id          string    `xml:"id,attr"`
-	Name        string    `xml:"name"`
+	Description *string   `xml:"description"`
+	Id          *string   `xml:"id,attr"`
+	Name        *string   `xml:"name"`
 	Permits     []Permit  `xml:"permits"`
 }
 
@@ -2421,10 +2421,10 @@ type CpuProfiles struct {
 type CpuProfile struct {
 	OvStruct
 	Cluster     *Cluster     `xml:"cluster"`
-	Comment     string       `xml:"comment"`
-	Description string       `xml:"description"`
-	Id          string       `xml:"id,attr"`
-	Name        string       `xml:"name"`
+	Comment     *string      `xml:"comment"`
+	Description *string      `xml:"description"`
+	Id          *string      `xml:"id,attr"`
+	Name        *string      `xml:"name"`
 	Permissions []Permission `xml:"permissions"`
 	Qos         *Qos         `xml:"qos"`
 }
@@ -2437,13 +2437,13 @@ type DataCenters struct {
 type DataCenter struct {
 	OvStruct
 	Clusters          []Cluster        `xml:"clusters"`
-	Comment           string           `xml:"comment"`
-	Description       string           `xml:"description"`
-	Id                string           `xml:"id,attr"`
+	Comment           *string          `xml:"comment"`
+	Description       *string          `xml:"description"`
+	Id                *string          `xml:"id,attr"`
 	IscsiBonds        []IscsiBond      `xml:"iscsi_bonds"`
-	Local             bool             `xml:"local"`
+	Local             *bool            `xml:"local"`
 	MacPool           *MacPool         `xml:"mac_pool"`
-	Name              string           `xml:"name"`
+	Name              *string          `xml:"name"`
 	Networks          []Network        `xml:"networks"`
 	Permissions       []Permission     `xml:"permissions"`
 	Qoss              []Qos            `xml:"qoss"`
@@ -2463,11 +2463,11 @@ type Devices struct {
 
 type Device struct {
 	OvStruct
-	Comment      string        `xml:"comment"`
-	Description  string        `xml:"description"`
-	Id           string        `xml:"id,attr"`
+	Comment      *string       `xml:"comment"`
+	Description  *string       `xml:"description"`
+	Id           *string       `xml:"id,attr"`
 	InstanceType *InstanceType `xml:"instance_type"`
-	Name         string        `xml:"name"`
+	Name         *string       `xml:"name"`
 	Template     *Template     `xml:"template"`
 	Vm           *Vm           `xml:"vm"`
 	Vms          []Vm          `xml:"vms"`
@@ -2480,43 +2480,43 @@ type Disks struct {
 
 type Disk struct {
 	OvStruct
-	Active              bool                 `xml:"active"`
-	ActualSize          int64                `xml:"actual_size"`
-	Alias               string               `xml:"alias"`
-	Bootable            bool                 `xml:"bootable"`
-	Comment             string               `xml:"comment"`
-	Description         string               `xml:"description"`
+	Active              *bool                `xml:"active"`
+	ActualSize          *int64               `xml:"actual_size"`
+	Alias               *string              `xml:"alias"`
+	Bootable            *bool                `xml:"bootable"`
+	Comment             *string              `xml:"comment"`
+	Description         *string              `xml:"description"`
 	DiskProfile         *DiskProfile         `xml:"disk_profile"`
 	Format              DiskFormat           `xml:"format"`
-	Id                  string               `xml:"id,attr"`
-	ImageId             string               `xml:"image_id"`
-	InitialSize         int64                `xml:"initial_size"`
+	Id                  *string              `xml:"id,attr"`
+	ImageId             *string              `xml:"image_id"`
+	InitialSize         *int64               `xml:"initial_size"`
 	InstanceType        *InstanceType        `xml:"instance_type"`
 	Interface           DiskInterface        `xml:"interface"`
-	LogicalName         string               `xml:"logical_name"`
+	LogicalName         *string              `xml:"logical_name"`
 	LunStorage          *HostStorage         `xml:"lun_storage"`
-	Name                string               `xml:"name"`
+	Name                *string              `xml:"name"`
 	OpenstackVolumeType *OpenStackVolumeType `xml:"openstack_volume_type"`
 	Permissions         []Permission         `xml:"permissions"`
-	PropagateErrors     bool                 `xml:"propagate_errors"`
-	ProvisionedSize     int64                `xml:"provisioned_size"`
+	PropagateErrors     *bool                `xml:"propagate_errors"`
+	ProvisionedSize     *int64               `xml:"provisioned_size"`
 	QcowVersion         QcowVersion          `xml:"qcow_version"`
 	Quota               *Quota               `xml:"quota"`
-	ReadOnly            bool                 `xml:"read_only"`
+	ReadOnly            *bool                `xml:"read_only"`
 	Sgio                ScsiGenericIO        `xml:"sgio"`
-	Shareable           bool                 `xml:"shareable"`
+	Shareable           *bool                `xml:"shareable"`
 	Snapshot            *Snapshot            `xml:"snapshot"`
-	Sparse              bool                 `xml:"sparse"`
+	Sparse              *bool                `xml:"sparse"`
 	Statistics          []Statistic          `xml:"statistics"`
 	Status              DiskStatus           `xml:"status"`
 	StorageDomain       *StorageDomain       `xml:"storage_domain"`
 	StorageDomains      []StorageDomain      `xml:"storage_domains"`
 	StorageType         DiskStorageType      `xml:"storage_type"`
 	Template            *Template            `xml:"template"`
-	UsesScsiReservation bool                 `xml:"uses_scsi_reservation"`
+	UsesScsiReservation *bool                `xml:"uses_scsi_reservation"`
 	Vm                  *Vm                  `xml:"vm"`
 	Vms                 []Vm                 `xml:"vms"`
-	WipeAfterDelete     bool                 `xml:"wipe_after_delete"`
+	WipeAfterDelete     *bool                `xml:"wipe_after_delete"`
 }
 
 type DiskAttachments struct {
@@ -2526,18 +2526,18 @@ type DiskAttachments struct {
 
 type DiskAttachment struct {
 	OvStruct
-	Active              bool          `xml:"active"`
-	Bootable            bool          `xml:"bootable"`
-	Comment             string        `xml:"comment"`
-	Description         string        `xml:"description"`
+	Active              *bool         `xml:"active"`
+	Bootable            *bool         `xml:"bootable"`
+	Comment             *string       `xml:"comment"`
+	Description         *string       `xml:"description"`
 	Disk                *Disk         `xml:"disk"`
-	Id                  string        `xml:"id,attr"`
+	Id                  *string       `xml:"id,attr"`
 	Interface           DiskInterface `xml:"interface"`
-	LogicalName         string        `xml:"logical_name"`
-	Name                string        `xml:"name"`
-	PassDiscard         bool          `xml:"pass_discard"`
+	LogicalName         *string       `xml:"logical_name"`
+	Name                *string       `xml:"name"`
+	PassDiscard         *bool         `xml:"pass_discard"`
 	Template            *Template     `xml:"template"`
-	UsesScsiReservation bool          `xml:"uses_scsi_reservation"`
+	UsesScsiReservation *bool         `xml:"uses_scsi_reservation"`
 	Vm                  *Vm           `xml:"vm"`
 }
 
@@ -2548,10 +2548,10 @@ type DiskProfiles struct {
 
 type DiskProfile struct {
 	OvStruct
-	Comment       string         `xml:"comment"`
-	Description   string         `xml:"description"`
-	Id            string         `xml:"id,attr"`
-	Name          string         `xml:"name"`
+	Comment       *string        `xml:"comment"`
+	Description   *string        `xml:"description"`
+	Id            *string        `xml:"id,attr"`
+	Name          *string        `xml:"name"`
 	Permissions   []Permission   `xml:"permissions"`
 	Qos           *Qos           `xml:"qos"`
 	StorageDomain *StorageDomain `xml:"storage_domain"`
@@ -2564,44 +2564,44 @@ type DiskSnapshots struct {
 
 type DiskSnapshot struct {
 	OvStruct
-	Active              bool                 `xml:"active"`
-	ActualSize          int64                `xml:"actual_size"`
-	Alias               string               `xml:"alias"`
-	Bootable            bool                 `xml:"bootable"`
-	Comment             string               `xml:"comment"`
-	Description         string               `xml:"description"`
+	Active              *bool                `xml:"active"`
+	ActualSize          *int64               `xml:"actual_size"`
+	Alias               *string              `xml:"alias"`
+	Bootable            *bool                `xml:"bootable"`
+	Comment             *string              `xml:"comment"`
+	Description         *string              `xml:"description"`
 	Disk                *Disk                `xml:"disk"`
 	DiskProfile         *DiskProfile         `xml:"disk_profile"`
 	Format              DiskFormat           `xml:"format"`
-	Id                  string               `xml:"id,attr"`
-	ImageId             string               `xml:"image_id"`
-	InitialSize         int64                `xml:"initial_size"`
+	Id                  *string              `xml:"id,attr"`
+	ImageId             *string              `xml:"image_id"`
+	InitialSize         *int64               `xml:"initial_size"`
 	InstanceType        *InstanceType        `xml:"instance_type"`
 	Interface           DiskInterface        `xml:"interface"`
-	LogicalName         string               `xml:"logical_name"`
+	LogicalName         *string              `xml:"logical_name"`
 	LunStorage          *HostStorage         `xml:"lun_storage"`
-	Name                string               `xml:"name"`
+	Name                *string              `xml:"name"`
 	OpenstackVolumeType *OpenStackVolumeType `xml:"openstack_volume_type"`
 	Permissions         []Permission         `xml:"permissions"`
-	PropagateErrors     bool                 `xml:"propagate_errors"`
-	ProvisionedSize     int64                `xml:"provisioned_size"`
+	PropagateErrors     *bool                `xml:"propagate_errors"`
+	ProvisionedSize     *int64               `xml:"provisioned_size"`
 	QcowVersion         QcowVersion          `xml:"qcow_version"`
 	Quota               *Quota               `xml:"quota"`
-	ReadOnly            bool                 `xml:"read_only"`
+	ReadOnly            *bool                `xml:"read_only"`
 	Sgio                ScsiGenericIO        `xml:"sgio"`
-	Shareable           bool                 `xml:"shareable"`
+	Shareable           *bool                `xml:"shareable"`
 	Snapshot            *Snapshot            `xml:"snapshot"`
-	Sparse              bool                 `xml:"sparse"`
+	Sparse              *bool                `xml:"sparse"`
 	Statistics          []Statistic          `xml:"statistics"`
 	Status              DiskStatus           `xml:"status"`
 	StorageDomain       *StorageDomain       `xml:"storage_domain"`
 	StorageDomains      []StorageDomain      `xml:"storage_domains"`
 	StorageType         DiskStorageType      `xml:"storage_type"`
 	Template            *Template            `xml:"template"`
-	UsesScsiReservation bool                 `xml:"uses_scsi_reservation"`
+	UsesScsiReservation *bool                `xml:"uses_scsi_reservation"`
 	Vm                  *Vm                  `xml:"vm"`
 	Vms                 []Vm                 `xml:"vms"`
-	WipeAfterDelete     bool                 `xml:"wipe_after_delete"`
+	WipeAfterDelete     *bool                `xml:"wipe_after_delete"`
 }
 
 type Domains struct {
@@ -2611,11 +2611,11 @@ type Domains struct {
 
 type Domain struct {
 	OvStruct
-	Comment     string  `xml:"comment"`
-	Description string  `xml:"description"`
+	Comment     *string `xml:"comment"`
+	Description *string `xml:"description"`
 	Groups      []Group `xml:"groups"`
-	Id          string  `xml:"id,attr"`
-	Name        string  `xml:"name"`
+	Id          *string `xml:"id,attr"`
+	Name        *string `xml:"name"`
 	User        *User   `xml:"user"`
 	Users       []User  `xml:"users"`
 }
@@ -2628,18 +2628,18 @@ type Events struct {
 type Event struct {
 	OvStruct
 	Cluster       *Cluster       `xml:"cluster"`
-	Code          int64          `xml:"code"`
-	Comment       string         `xml:"comment"`
-	CorrelationId string         `xml:"correlation_id"`
-	CustomData    string         `xml:"custom_data"`
-	CustomId      int64          `xml:"custom_id"`
+	Code          *int64         `xml:"code"`
+	Comment       *string        `xml:"comment"`
+	CorrelationId *string        `xml:"correlation_id"`
+	CustomData    *string        `xml:"custom_data"`
+	CustomId      *int64         `xml:"custom_id"`
 	DataCenter    *DataCenter    `xml:"data_center"`
-	Description   string         `xml:"description"`
-	FloodRate     int64          `xml:"flood_rate"`
+	Description   *string        `xml:"description"`
+	FloodRate     *int64         `xml:"flood_rate"`
 	Host          *Host          `xml:"host"`
-	Id            string         `xml:"id,attr"`
-	Name          string         `xml:"name"`
-	Origin        string         `xml:"origin"`
+	Id            *string        `xml:"id,attr"`
+	Name          *string        `xml:"name"`
+	Origin        *string        `xml:"origin"`
 	Severity      LogSeverity    `xml:"severity"`
 	StorageDomain *StorageDomain `xml:"storage_domain"`
 	Template      *Template      `xml:"template"`
@@ -2655,14 +2655,14 @@ type ExternalComputeResources struct {
 
 type ExternalComputeResource struct {
 	OvStruct
-	Comment              string                `xml:"comment"`
-	Description          string                `xml:"description"`
+	Comment              *string               `xml:"comment"`
+	Description          *string               `xml:"description"`
 	ExternalHostProvider *ExternalHostProvider `xml:"external_host_provider"`
-	Id                   string                `xml:"id,attr"`
-	Name                 string                `xml:"name"`
-	Provider             string                `xml:"provider"`
-	Url                  string                `xml:"url"`
-	User                 string                `xml:"user"`
+	Id                   *string               `xml:"id,attr"`
+	Name                 *string               `xml:"name"`
+	Provider             *string               `xml:"provider"`
+	Url                  *string               `xml:"url"`
+	User                 *string               `xml:"user"`
 }
 
 type ExternalDiscoveredHosts struct {
@@ -2672,15 +2672,15 @@ type ExternalDiscoveredHosts struct {
 
 type ExternalDiscoveredHost struct {
 	OvStruct
-	Comment              string                `xml:"comment"`
-	Description          string                `xml:"description"`
+	Comment              *string               `xml:"comment"`
+	Description          *string               `xml:"description"`
 	ExternalHostProvider *ExternalHostProvider `xml:"external_host_provider"`
-	Id                   string                `xml:"id,attr"`
-	Ip                   string                `xml:"ip"`
-	LastReport           string                `xml:"last_report"`
-	Mac                  string                `xml:"mac"`
-	Name                 string                `xml:"name"`
-	SubnetName           string                `xml:"subnet_name"`
+	Id                   *string               `xml:"id,attr"`
+	Ip                   *string               `xml:"ip"`
+	LastReport           *string               `xml:"last_report"`
+	Mac                  *string               `xml:"mac"`
+	Name                 *string               `xml:"name"`
+	SubnetName           *string               `xml:"subnet_name"`
 }
 
 type ExternalHosts struct {
@@ -2690,12 +2690,12 @@ type ExternalHosts struct {
 
 type ExternalHost struct {
 	OvStruct
-	Address              string                `xml:"address"`
-	Comment              string                `xml:"comment"`
-	Description          string                `xml:"description"`
+	Address              *string               `xml:"address"`
+	Comment              *string               `xml:"comment"`
+	Description          *string               `xml:"description"`
 	ExternalHostProvider *ExternalHostProvider `xml:"external_host_provider"`
-	Id                   string                `xml:"id,attr"`
-	Name                 string                `xml:"name"`
+	Id                   *string               `xml:"id,attr"`
+	Name                 *string               `xml:"name"`
 }
 
 type ExternalHostGroups struct {
@@ -2705,15 +2705,15 @@ type ExternalHostGroups struct {
 
 type ExternalHostGroup struct {
 	OvStruct
-	ArchitectureName     string                `xml:"architecture_name"`
-	Comment              string                `xml:"comment"`
-	Description          string                `xml:"description"`
-	DomainName           string                `xml:"domain_name"`
+	ArchitectureName     *string               `xml:"architecture_name"`
+	Comment              *string               `xml:"comment"`
+	Description          *string               `xml:"description"`
+	DomainName           *string               `xml:"domain_name"`
 	ExternalHostProvider *ExternalHostProvider `xml:"external_host_provider"`
-	Id                   string                `xml:"id,attr"`
-	Name                 string                `xml:"name"`
-	OperatingSystemName  string                `xml:"operating_system_name"`
-	SubnetName           string                `xml:"subnet_name"`
+	Id                   *string               `xml:"id,attr"`
+	Name                 *string               `xml:"name"`
+	OperatingSystemName  *string               `xml:"operating_system_name"`
+	SubnetName           *string               `xml:"subnet_name"`
 }
 
 type ExternalProviders struct {
@@ -2723,16 +2723,16 @@ type ExternalProviders struct {
 
 type ExternalProvider struct {
 	OvStruct
-	AuthenticationUrl      string     `xml:"authentication_url"`
-	Comment                string     `xml:"comment"`
-	Description            string     `xml:"description"`
-	Id                     string     `xml:"id,attr"`
-	Name                   string     `xml:"name"`
-	Password               string     `xml:"password"`
+	AuthenticationUrl      *string    `xml:"authentication_url"`
+	Comment                *string    `xml:"comment"`
+	Description            *string    `xml:"description"`
+	Id                     *string    `xml:"id,attr"`
+	Name                   *string    `xml:"name"`
+	Password               *string    `xml:"password"`
 	Properties             []Property `xml:"properties"`
-	RequiresAuthentication bool       `xml:"requires_authentication"`
-	Url                    string     `xml:"url"`
-	Username               string     `xml:"username"`
+	RequiresAuthentication *bool      `xml:"requires_authentication"`
+	Url                    *string    `xml:"url"`
+	Username               *string    `xml:"username"`
 }
 
 type Files struct {
@@ -2742,13 +2742,13 @@ type Files struct {
 
 type File struct {
 	OvStruct
-	Comment       string         `xml:"comment"`
-	Content       string         `xml:"content"`
-	Description   string         `xml:"description"`
-	Id            string         `xml:"id,attr"`
-	Name          string         `xml:"name"`
+	Comment       *string        `xml:"comment"`
+	Content       *string        `xml:"content"`
+	Description   *string        `xml:"description"`
+	Id            *string        `xml:"id,attr"`
+	Name          *string        `xml:"name"`
 	StorageDomain *StorageDomain `xml:"storage_domain"`
-	Type          string         `xml:"type"`
+	Type          *string        `xml:"type"`
 }
 
 type Filters struct {
@@ -2758,11 +2758,11 @@ type Filters struct {
 
 type Filter struct {
 	OvStruct
-	Comment              string                `xml:"comment"`
-	Description          string                `xml:"description"`
-	Id                   string                `xml:"id,attr"`
-	Name                 string                `xml:"name"`
-	Position             int64                 `xml:"position"`
+	Comment              *string               `xml:"comment"`
+	Description          *string               `xml:"description"`
+	Id                   *string               `xml:"id,attr"`
+	Name                 *string               `xml:"name"`
+	Position             *int64                `xml:"position"`
 	SchedulingPolicyUnit *SchedulingPolicyUnit `xml:"scheduling_policy_unit"`
 }
 
@@ -2773,12 +2773,12 @@ type Floppys struct {
 
 type Floppy struct {
 	OvStruct
-	Comment      string        `xml:"comment"`
-	Description  string        `xml:"description"`
+	Comment      *string       `xml:"comment"`
+	Description  *string       `xml:"description"`
 	File         *File         `xml:"file"`
-	Id           string        `xml:"id,attr"`
+	Id           *string       `xml:"id,attr"`
 	InstanceType *InstanceType `xml:"instance_type"`
-	Name         string        `xml:"name"`
+	Name         *string       `xml:"name"`
 	Template     *Template     `xml:"template"`
 	Vm           *Vm           `xml:"vm"`
 	Vms          []Vm          `xml:"vms"`
@@ -2791,18 +2791,18 @@ type GlusterBrickAdvancedDetailss struct {
 
 type GlusterBrickAdvancedDetails struct {
 	OvStruct
-	Comment        string              `xml:"comment"`
-	Description    string              `xml:"description"`
-	Device         string              `xml:"device"`
-	FsName         string              `xml:"fs_name"`
+	Comment        *string             `xml:"comment"`
+	Description    *string             `xml:"description"`
+	Device         *string             `xml:"device"`
+	FsName         *string             `xml:"fs_name"`
 	GlusterClients []GlusterClient     `xml:"gluster_clients"`
-	Id             string              `xml:"id,attr"`
+	Id             *string             `xml:"id,attr"`
 	InstanceType   *InstanceType       `xml:"instance_type"`
 	MemoryPools    []GlusterMemoryPool `xml:"memory_pools"`
-	MntOptions     string              `xml:"mnt_options"`
-	Name           string              `xml:"name"`
-	Pid            int64               `xml:"pid"`
-	Port           int64               `xml:"port"`
+	MntOptions     *string             `xml:"mnt_options"`
+	Name           *string             `xml:"name"`
+	Pid            *int64              `xml:"pid"`
+	Port           *int64              `xml:"port"`
 	Template       *Template           `xml:"template"`
 	Vm             *Vm                 `xml:"vm"`
 	Vms            []Vm                `xml:"vms"`
@@ -2815,17 +2815,17 @@ type GlusterHooks struct {
 
 type GlusterHook struct {
 	OvStruct
-	Checksum       string              `xml:"checksum"`
+	Checksum       *string             `xml:"checksum"`
 	Cluster        *Cluster            `xml:"cluster"`
-	Comment        string              `xml:"comment"`
-	ConflictStatus int64               `xml:"conflict_status"`
-	Conflicts      string              `xml:"conflicts"`
-	Content        string              `xml:"content"`
+	Comment        *string             `xml:"comment"`
+	ConflictStatus *int64              `xml:"conflict_status"`
+	Conflicts      *string             `xml:"conflicts"`
+	Content        *string             `xml:"content"`
 	ContentType    HookContentType     `xml:"content_type"`
-	Description    string              `xml:"description"`
-	GlusterCommand string              `xml:"gluster_command"`
-	Id             string              `xml:"id,attr"`
-	Name           string              `xml:"name"`
+	Description    *string             `xml:"description"`
+	GlusterCommand *string             `xml:"gluster_command"`
+	Id             *string             `xml:"id,attr"`
+	Name           *string             `xml:"name"`
 	ServerHooks    []GlusterServerHook `xml:"server_hooks"`
 	Stage          HookStage           `xml:"stage"`
 	Status         GlusterHookStatus   `xml:"status"`
@@ -2838,18 +2838,18 @@ type GlusterMemoryPools struct {
 
 type GlusterMemoryPool struct {
 	OvStruct
-	AllocCount  int64  `xml:"alloc_count"`
-	ColdCount   int64  `xml:"cold_count"`
-	Comment     string `xml:"comment"`
-	Description string `xml:"description"`
-	HotCount    int64  `xml:"hot_count"`
-	Id          string `xml:"id,attr"`
-	MaxAlloc    int64  `xml:"max_alloc"`
-	MaxStdalloc int64  `xml:"max_stdalloc"`
-	Name        string `xml:"name"`
-	PaddedSize  int64  `xml:"padded_size"`
-	PoolMisses  int64  `xml:"pool_misses"`
-	Type        string `xml:"type"`
+	AllocCount  *int64  `xml:"alloc_count"`
+	ColdCount   *int64  `xml:"cold_count"`
+	Comment     *string `xml:"comment"`
+	Description *string `xml:"description"`
+	HotCount    *int64  `xml:"hot_count"`
+	Id          *string `xml:"id,attr"`
+	MaxAlloc    *int64  `xml:"max_alloc"`
+	MaxStdalloc *int64  `xml:"max_stdalloc"`
+	Name        *string `xml:"name"`
+	PaddedSize  *int64  `xml:"padded_size"`
+	PoolMisses  *int64  `xml:"pool_misses"`
+	Type        *string `xml:"type"`
 }
 
 type GlusterServerHooks struct {
@@ -2859,13 +2859,13 @@ type GlusterServerHooks struct {
 
 type GlusterServerHook struct {
 	OvStruct
-	Checksum    string            `xml:"checksum"`
-	Comment     string            `xml:"comment"`
+	Checksum    *string           `xml:"checksum"`
+	Comment     *string           `xml:"comment"`
 	ContentType HookContentType   `xml:"content_type"`
-	Description string            `xml:"description"`
+	Description *string           `xml:"description"`
 	Host        *Host             `xml:"host"`
-	Id          string            `xml:"id,attr"`
-	Name        string            `xml:"name"`
+	Id          *string           `xml:"id,attr"`
+	Name        *string           `xml:"name"`
 	Status      GlusterHookStatus `xml:"status"`
 }
 
@@ -2878,17 +2878,17 @@ type GlusterVolume struct {
 	OvStruct
 	Bricks          []GlusterBrick      `xml:"bricks"`
 	Cluster         *Cluster            `xml:"cluster"`
-	Comment         string              `xml:"comment"`
-	Description     string              `xml:"description"`
-	DisperseCount   int64               `xml:"disperse_count"`
-	Id              string              `xml:"id,attr"`
-	Name            string              `xml:"name"`
+	Comment         *string             `xml:"comment"`
+	Description     *string             `xml:"description"`
+	DisperseCount   *int64              `xml:"disperse_count"`
+	Id              *string             `xml:"id,attr"`
+	Name            *string             `xml:"name"`
 	Options         []Option            `xml:"options"`
-	RedundancyCount int64               `xml:"redundancy_count"`
-	ReplicaCount    int64               `xml:"replica_count"`
+	RedundancyCount *int64              `xml:"redundancy_count"`
+	ReplicaCount    *int64              `xml:"replica_count"`
 	Statistics      []Statistic         `xml:"statistics"`
 	Status          GlusterVolumeStatus `xml:"status"`
-	StripeCount     int64               `xml:"stripe_count"`
+	StripeCount     *int64              `xml:"stripe_count"`
 	TransportTypes  []TransportType     `xml:"transport_types"`
 	VolumeType      GlusterVolumeType   `xml:"volume_type"`
 }
@@ -2901,10 +2901,10 @@ type GlusterVolumeProfileDetailss struct {
 type GlusterVolumeProfileDetails struct {
 	OvStruct
 	BrickProfileDetails []BrickProfileDetail `xml:"brick_profile_details"`
-	Comment             string               `xml:"comment"`
-	Description         string               `xml:"description"`
-	Id                  string               `xml:"id,attr"`
-	Name                string               `xml:"name"`
+	Comment             *string              `xml:"comment"`
+	Description         *string              `xml:"description"`
+	Id                  *string              `xml:"id,attr"`
+	Name                *string              `xml:"name"`
 	NfsProfileDetails   []NfsProfileDetail   `xml:"nfs_profile_details"`
 }
 
@@ -2915,16 +2915,16 @@ type GraphicsConsoles struct {
 
 type GraphicsConsole struct {
 	OvStruct
-	Address      string        `xml:"address"`
-	Comment      string        `xml:"comment"`
-	Description  string        `xml:"description"`
-	Id           string        `xml:"id,attr"`
+	Address      *string       `xml:"address"`
+	Comment      *string       `xml:"comment"`
+	Description  *string       `xml:"description"`
+	Id           *string       `xml:"id,attr"`
 	InstanceType *InstanceType `xml:"instance_type"`
-	Name         string        `xml:"name"`
-	Port         int64         `xml:"port"`
+	Name         *string       `xml:"name"`
+	Port         *int64        `xml:"port"`
 	Protocol     GraphicsType  `xml:"protocol"`
 	Template     *Template     `xml:"template"`
-	TlsPort      int64         `xml:"tls_port"`
+	TlsPort      *int64        `xml:"tls_port"`
 	Vm           *Vm           `xml:"vm"`
 }
 
@@ -2935,13 +2935,13 @@ type Groups struct {
 
 type Group struct {
 	OvStruct
-	Comment       string       `xml:"comment"`
-	Description   string       `xml:"description"`
+	Comment       *string      `xml:"comment"`
+	Description   *string      `xml:"description"`
 	Domain        *Domain      `xml:"domain"`
-	DomainEntryId string       `xml:"domain_entry_id"`
-	Id            string       `xml:"id,attr"`
-	Name          string       `xml:"name"`
-	Namespace     string       `xml:"namespace"`
+	DomainEntryId *string      `xml:"domain_entry_id"`
+	Id            *string      `xml:"id,attr"`
+	Name          *string      `xml:"name"`
+	Namespace     *string      `xml:"namespace"`
 	Permissions   []Permission `xml:"permissions"`
 	Roles         []Role       `xml:"roles"`
 	Tags          []Tag        `xml:"tags"`
@@ -2954,13 +2954,13 @@ type Hooks struct {
 
 type Hook struct {
 	OvStruct
-	Comment     string `xml:"comment"`
-	Description string `xml:"description"`
-	EventName   string `xml:"event_name"`
-	Host        *Host  `xml:"host"`
-	Id          string `xml:"id,attr"`
-	Md5         string `xml:"md5"`
-	Name        string `xml:"name"`
+	Comment     *string `xml:"comment"`
+	Description *string `xml:"description"`
+	EventName   *string `xml:"event_name"`
+	Host        *Host   `xml:"host"`
+	Id          *string `xml:"id,attr"`
+	Md5         *string `xml:"md5"`
+	Name        *string `xml:"name"`
 }
 
 type Hosts struct {
@@ -2970,15 +2970,15 @@ type Hosts struct {
 
 type Host struct {
 	OvStruct
-	Address                     string                       `xml:"address"`
+	Address                     *string                      `xml:"address"`
 	AffinityLabels              []AffinityLabel              `xml:"affinity_labels"`
 	Agents                      []Agent                      `xml:"agents"`
 	AutoNumaStatus              AutoNumaStatus               `xml:"auto_numa_status"`
 	Certificate                 *Certificate                 `xml:"certificate"`
 	Cluster                     *Cluster                     `xml:"cluster"`
-	Comment                     string                       `xml:"comment"`
+	Comment                     *string                      `xml:"comment"`
 	Cpu                         *Cpu                         `xml:"cpu"`
-	Description                 string                       `xml:"description"`
+	Description                 *string                      `xml:"description"`
 	DevicePassthrough           *HostDevicePassthrough       `xml:"device_passthrough"`
 	Devices                     []Device                     `xml:"devices"`
 	Display                     *Display                     `xml:"display"`
@@ -2987,32 +2987,32 @@ type Host struct {
 	HardwareInformation         *HardwareInformation         `xml:"hardware_information"`
 	Hooks                       []Hook                       `xml:"hooks"`
 	HostedEngine                *HostedEngine                `xml:"hosted_engine"`
-	Id                          string                       `xml:"id,attr"`
+	Id                          *string                      `xml:"id,attr"`
 	Iscsi                       *IscsiDetails                `xml:"iscsi"`
 	KatelloErrata               []KatelloErratum             `xml:"katello_errata"`
 	KdumpStatus                 KdumpStatus                  `xml:"kdump_status"`
 	Ksm                         *Ksm                         `xml:"ksm"`
 	LibvirtVersion              *Version                     `xml:"libvirt_version"`
-	MaxSchedulingMemory         int64                        `xml:"max_scheduling_memory"`
-	Memory                      int64                        `xml:"memory"`
-	Name                        string                       `xml:"name"`
+	MaxSchedulingMemory         *int64                       `xml:"max_scheduling_memory"`
+	Memory                      *int64                       `xml:"memory"`
+	Name                        *string                      `xml:"name"`
 	NetworkAttachments          []NetworkAttachment          `xml:"network_attachments"`
 	Nics                        []Nic                        `xml:"nics"`
 	NumaNodes                   []NumaNode                   `xml:"numa_nodes"`
-	NumaSupported               bool                         `xml:"numa_supported"`
+	NumaSupported               *bool                        `xml:"numa_supported"`
 	Os                          *OperatingSystem             `xml:"os"`
-	OverrideIptables            bool                         `xml:"override_iptables"`
+	OverrideIptables            *bool                        `xml:"override_iptables"`
 	Permissions                 []Permission                 `xml:"permissions"`
-	Port                        int64                        `xml:"port"`
+	Port                        *int64                       `xml:"port"`
 	PowerManagement             *PowerManagement             `xml:"power_management"`
 	Protocol                    HostProtocol                 `xml:"protocol"`
-	RootPassword                string                       `xml:"root_password"`
+	RootPassword                *string                      `xml:"root_password"`
 	SeLinux                     *SeLinux                     `xml:"se_linux"`
 	Spm                         *Spm                         `xml:"spm"`
 	Ssh                         *Ssh                         `xml:"ssh"`
 	Statistics                  []Statistic                  `xml:"statistics"`
 	Status                      HostStatus                   `xml:"status"`
-	StatusDetail                string                       `xml:"status_detail"`
+	StatusDetail                *string                      `xml:"status_detail"`
 	StorageConnectionExtensions []StorageConnectionExtension `xml:"storage_connection_extensions"`
 	Storages                    []HostStorage                `xml:"storages"`
 	Summary                     *VmSummary                   `xml:"summary"`
@@ -3020,7 +3020,7 @@ type Host struct {
 	TransparentHugePages        *TransparentHugePages        `xml:"transparent_huge_pages"`
 	Type                        HostType                     `xml:"type"`
 	UnmanagedNetworks           []UnmanagedNetwork           `xml:"unmanaged_networks"`
-	UpdateAvailable             bool                         `xml:"update_available"`
+	UpdateAvailable             *bool                        `xml:"update_available"`
 	Version                     *Version                     `xml:"version"`
 }
 
@@ -3031,19 +3031,19 @@ type HostDevices struct {
 
 type HostDevice struct {
 	OvStruct
-	Capability       string      `xml:"capability"`
-	Comment          string      `xml:"comment"`
-	Description      string      `xml:"description"`
+	Capability       *string     `xml:"capability"`
+	Comment          *string     `xml:"comment"`
+	Description      *string     `xml:"description"`
 	Host             *Host       `xml:"host"`
-	Id               string      `xml:"id,attr"`
-	IommuGroup       int64       `xml:"iommu_group"`
-	Name             string      `xml:"name"`
+	Id               *string     `xml:"id,attr"`
+	IommuGroup       *int64      `xml:"iommu_group"`
+	Name             *string     `xml:"name"`
 	ParentDevice     *HostDevice `xml:"parent_device"`
 	PhysicalFunction *HostDevice `xml:"physical_function"`
-	Placeholder      bool        `xml:"placeholder"`
+	Placeholder      *bool       `xml:"placeholder"`
 	Product          *Product    `xml:"product"`
 	Vendor           *Vendor     `xml:"vendor"`
-	VirtualFunctions int64       `xml:"virtual_functions"`
+	VirtualFunctions *int64      `xml:"virtual_functions"`
 	Vm               *Vm         `xml:"vm"`
 }
 
@@ -3054,30 +3054,30 @@ type HostNics struct {
 
 type HostNic struct {
 	OvStruct
-	AdAggregatorId                int64                                 `xml:"ad_aggregator_id"`
-	BaseInterface                 string                                `xml:"base_interface"`
+	AdAggregatorId                *int64                                `xml:"ad_aggregator_id"`
+	BaseInterface                 *string                               `xml:"base_interface"`
 	Bonding                       *Bonding                              `xml:"bonding"`
 	BootProtocol                  BootProtocol                          `xml:"boot_protocol"`
-	Bridged                       bool                                  `xml:"bridged"`
-	CheckConnectivity             bool                                  `xml:"check_connectivity"`
-	Comment                       string                                `xml:"comment"`
-	CustomConfiguration           bool                                  `xml:"custom_configuration"`
-	Description                   string                                `xml:"description"`
+	Bridged                       *bool                                 `xml:"bridged"`
+	CheckConnectivity             *bool                                 `xml:"check_connectivity"`
+	Comment                       *string                               `xml:"comment"`
+	CustomConfiguration           *bool                                 `xml:"custom_configuration"`
+	Description                   *string                               `xml:"description"`
 	Host                          *Host                                 `xml:"host"`
-	Id                            string                                `xml:"id,attr"`
+	Id                            *string                               `xml:"id,attr"`
 	Ip                            *Ip                                   `xml:"ip"`
 	Ipv6                          *Ip                                   `xml:"ipv6"`
 	Ipv6BootProtocol              BootProtocol                          `xml:"ipv6_boot_protocol"`
 	Mac                           *Mac                                  `xml:"mac"`
-	Mtu                           int64                                 `xml:"mtu"`
-	Name                          string                                `xml:"name"`
+	Mtu                           *int64                                `xml:"mtu"`
+	Name                          *string                               `xml:"name"`
 	Network                       *Network                              `xml:"network"`
 	NetworkLabels                 []NetworkLabel                        `xml:"network_labels"`
-	OverrideConfiguration         bool                                  `xml:"override_configuration"`
+	OverrideConfiguration         *bool                                 `xml:"override_configuration"`
 	PhysicalFunction              *HostNic                              `xml:"physical_function"`
 	Properties                    []Property                            `xml:"properties"`
 	Qos                           *Qos                                  `xml:"qos"`
-	Speed                         int64                                 `xml:"speed"`
+	Speed                         *int64                                `xml:"speed"`
 	Statistics                    []Statistic                           `xml:"statistics"`
 	Status                        NicStatus                             `xml:"status"`
 	VirtualFunctionsConfiguration *HostNicVirtualFunctionsConfiguration `xml:"virtual_functions_configuration"`
@@ -3091,26 +3091,26 @@ type HostStorages struct {
 
 type HostStorage struct {
 	OvStruct
-	Address      string        `xml:"address"`
-	Comment      string        `xml:"comment"`
-	Description  string        `xml:"description"`
+	Address      *string       `xml:"address"`
+	Comment      *string       `xml:"comment"`
+	Description  *string       `xml:"description"`
 	Host         *Host         `xml:"host"`
-	Id           string        `xml:"id,attr"`
+	Id           *string       `xml:"id,attr"`
 	LogicalUnits []LogicalUnit `xml:"logical_units"`
-	MountOptions string        `xml:"mount_options"`
-	Name         string        `xml:"name"`
-	NfsRetrans   int64         `xml:"nfs_retrans"`
-	NfsTimeo     int64         `xml:"nfs_timeo"`
+	MountOptions *string       `xml:"mount_options"`
+	Name         *string       `xml:"name"`
+	NfsRetrans   *int64        `xml:"nfs_retrans"`
+	NfsTimeo     *int64        `xml:"nfs_timeo"`
 	NfsVersion   NfsVersion    `xml:"nfs_version"`
-	OverrideLuns bool          `xml:"override_luns"`
-	Password     string        `xml:"password"`
-	Path         string        `xml:"path"`
-	Port         int64         `xml:"port"`
-	Portal       string        `xml:"portal"`
-	Target       string        `xml:"target"`
+	OverrideLuns *bool         `xml:"override_luns"`
+	Password     *string       `xml:"password"`
+	Path         *string       `xml:"path"`
+	Port         *int64        `xml:"port"`
+	Portal       *string       `xml:"portal"`
+	Target       *string       `xml:"target"`
 	Type         StorageType   `xml:"type"`
-	Username     string        `xml:"username"`
-	VfsType      string        `xml:"vfs_type"`
+	Username     *string       `xml:"username"`
+	VfsType      *string       `xml:"vfs_type"`
 	VolumeGroup  *VolumeGroup  `xml:"volume_group"`
 }
 
@@ -3121,12 +3121,12 @@ type Icons struct {
 
 type Icon struct {
 	OvStruct
-	Comment     string `xml:"comment"`
-	Data        string `xml:"data"`
-	Description string `xml:"description"`
-	Id          string `xml:"id,attr"`
-	MediaType   string `xml:"media_type"`
-	Name        string `xml:"name"`
+	Comment     *string `xml:"comment"`
+	Data        *string `xml:"data"`
+	Description *string `xml:"description"`
+	Id          *string `xml:"id,attr"`
+	MediaType   *string `xml:"media_type"`
+	Name        *string `xml:"name"`
 }
 
 type Nics struct {
@@ -3137,20 +3137,20 @@ type Nics struct {
 type Nic struct {
 	OvStruct
 	BootProtocol                   BootProtocol             `xml:"boot_protocol"`
-	Comment                        string                   `xml:"comment"`
-	Description                    string                   `xml:"description"`
-	Id                             string                   `xml:"id,attr"`
+	Comment                        *string                  `xml:"comment"`
+	Description                    *string                  `xml:"description"`
+	Id                             *string                  `xml:"id,attr"`
 	InstanceType                   *InstanceType            `xml:"instance_type"`
 	Interface                      NicInterface             `xml:"interface"`
-	Linked                         bool                     `xml:"linked"`
+	Linked                         *bool                    `xml:"linked"`
 	Mac                            *Mac                     `xml:"mac"`
-	Name                           string                   `xml:"name"`
+	Name                           *string                  `xml:"name"`
 	Network                        *Network                 `xml:"network"`
 	NetworkAttachments             []NetworkAttachment      `xml:"network_attachments"`
 	NetworkFilterParameters        []NetworkFilterParameter `xml:"network_filter_parameters"`
 	NetworkLabels                  []NetworkLabel           `xml:"network_labels"`
-	OnBoot                         bool                     `xml:"on_boot"`
-	Plugged                        bool                     `xml:"plugged"`
+	OnBoot                         *bool                    `xml:"on_boot"`
+	Plugged                        *bool                    `xml:"plugged"`
 	ReportedDevices                []ReportedDevice         `xml:"reported_devices"`
 	Statistics                     []Statistic              `xml:"statistics"`
 	Template                       *Template                `xml:"template"`
@@ -3168,17 +3168,17 @@ type OpenStackProviders struct {
 
 type OpenStackProvider struct {
 	OvStruct
-	AuthenticationUrl      string     `xml:"authentication_url"`
-	Comment                string     `xml:"comment"`
-	Description            string     `xml:"description"`
-	Id                     string     `xml:"id,attr"`
-	Name                   string     `xml:"name"`
-	Password               string     `xml:"password"`
+	AuthenticationUrl      *string    `xml:"authentication_url"`
+	Comment                *string    `xml:"comment"`
+	Description            *string    `xml:"description"`
+	Id                     *string    `xml:"id,attr"`
+	Name                   *string    `xml:"name"`
+	Password               *string    `xml:"password"`
 	Properties             []Property `xml:"properties"`
-	RequiresAuthentication bool       `xml:"requires_authentication"`
-	TenantName             string     `xml:"tenant_name"`
-	Url                    string     `xml:"url"`
-	Username               string     `xml:"username"`
+	RequiresAuthentication *bool      `xml:"requires_authentication"`
+	TenantName             *string    `xml:"tenant_name"`
+	Url                    *string    `xml:"url"`
+	Username               *string    `xml:"username"`
 }
 
 type OpenStackVolumeProviders struct {
@@ -3189,19 +3189,19 @@ type OpenStackVolumeProviders struct {
 type OpenStackVolumeProvider struct {
 	OvStruct
 	AuthenticationKeys     []OpenstackVolumeAuthenticationKey `xml:"authentication_keys"`
-	AuthenticationUrl      string                             `xml:"authentication_url"`
+	AuthenticationUrl      *string                            `xml:"authentication_url"`
 	Certificates           []Certificate                      `xml:"certificates"`
-	Comment                string                             `xml:"comment"`
+	Comment                *string                            `xml:"comment"`
 	DataCenter             *DataCenter                        `xml:"data_center"`
-	Description            string                             `xml:"description"`
-	Id                     string                             `xml:"id,attr"`
-	Name                   string                             `xml:"name"`
-	Password               string                             `xml:"password"`
+	Description            *string                            `xml:"description"`
+	Id                     *string                            `xml:"id,attr"`
+	Name                   *string                            `xml:"name"`
+	Password               *string                            `xml:"password"`
 	Properties             []Property                         `xml:"properties"`
-	RequiresAuthentication bool                               `xml:"requires_authentication"`
-	TenantName             string                             `xml:"tenant_name"`
-	Url                    string                             `xml:"url"`
-	Username               string                             `xml:"username"`
+	RequiresAuthentication *bool                              `xml:"requires_authentication"`
+	TenantName             *string                            `xml:"tenant_name"`
+	Url                    *string                            `xml:"url"`
+	Username               *string                            `xml:"username"`
 	VolumeTypes            []OpenStackVolumeType              `xml:"volume_types"`
 }
 
@@ -3215,50 +3215,50 @@ type Template struct {
 	Bios                       *Bios               `xml:"bios"`
 	Cdroms                     []Cdrom             `xml:"cdroms"`
 	Cluster                    *Cluster            `xml:"cluster"`
-	Comment                    string              `xml:"comment"`
+	Comment                    *string             `xml:"comment"`
 	Console                    *Console            `xml:"console"`
 	Cpu                        *Cpu                `xml:"cpu"`
 	CpuProfile                 *CpuProfile         `xml:"cpu_profile"`
-	CpuShares                  int64               `xml:"cpu_shares"`
+	CpuShares                  *int64              `xml:"cpu_shares"`
 	CreationTime               time.Time           `xml:"creation_time"`
 	CustomCompatibilityVersion *Version            `xml:"custom_compatibility_version"`
-	CustomCpuModel             string              `xml:"custom_cpu_model"`
-	CustomEmulatedMachine      string              `xml:"custom_emulated_machine"`
+	CustomCpuModel             *string             `xml:"custom_cpu_model"`
+	CustomEmulatedMachine      *string             `xml:"custom_emulated_machine"`
 	CustomProperties           []CustomProperty    `xml:"custom_properties"`
-	DeleteProtected            bool                `xml:"delete_protected"`
-	Description                string              `xml:"description"`
+	DeleteProtected            *bool               `xml:"delete_protected"`
+	Description                *string             `xml:"description"`
 	DiskAttachments            []DiskAttachment    `xml:"disk_attachments"`
 	Display                    *Display            `xml:"display"`
 	Domain                     *Domain             `xml:"domain"`
 	GraphicsConsoles           []GraphicsConsole   `xml:"graphics_consoles"`
 	HighAvailability           *HighAvailability   `xml:"high_availability"`
-	Id                         string              `xml:"id,attr"`
+	Id                         *string             `xml:"id,attr"`
 	Initialization             *Initialization     `xml:"initialization"`
 	Io                         *Io                 `xml:"io"`
 	LargeIcon                  *Icon               `xml:"large_icon"`
 	Lease                      *StorageDomainLease `xml:"lease"`
-	Memory                     int64               `xml:"memory"`
+	Memory                     *int64              `xml:"memory"`
 	MemoryPolicy               *MemoryPolicy       `xml:"memory_policy"`
 	Migration                  *MigrationOptions   `xml:"migration"`
-	MigrationDowntime          int64               `xml:"migration_downtime"`
-	Name                       string              `xml:"name"`
+	MigrationDowntime          *int64              `xml:"migration_downtime"`
+	Name                       *string             `xml:"name"`
 	Nics                       []Nic               `xml:"nics"`
-	Origin                     string              `xml:"origin"`
+	Origin                     *string             `xml:"origin"`
 	Os                         *OperatingSystem    `xml:"os"`
 	Permissions                []Permission        `xml:"permissions"`
 	Quota                      *Quota              `xml:"quota"`
 	RngDevice                  *RngDevice          `xml:"rng_device"`
 	SerialNumber               *SerialNumber       `xml:"serial_number"`
 	SmallIcon                  *Icon               `xml:"small_icon"`
-	SoundcardEnabled           bool                `xml:"soundcard_enabled"`
+	SoundcardEnabled           *bool               `xml:"soundcard_enabled"`
 	Sso                        *Sso                `xml:"sso"`
-	StartPaused                bool                `xml:"start_paused"`
-	Stateless                  bool                `xml:"stateless"`
+	StartPaused                *bool               `xml:"start_paused"`
+	Stateless                  *bool               `xml:"stateless"`
 	Status                     TemplateStatus      `xml:"status"`
 	StorageDomain              *StorageDomain      `xml:"storage_domain"`
 	Tags                       []Tag               `xml:"tags"`
 	TimeZone                   *TimeZone           `xml:"time_zone"`
-	TunnelMigration            bool                `xml:"tunnel_migration"`
+	TunnelMigration            *bool               `xml:"tunnel_migration"`
 	Type                       VmType              `xml:"type"`
 	Usb                        *Usb                `xml:"usb"`
 	Version                    *TemplateVersion    `xml:"version"`
@@ -3279,47 +3279,47 @@ type Vm struct {
 	Bios                       *Bios                 `xml:"bios"`
 	Cdroms                     []Cdrom               `xml:"cdroms"`
 	Cluster                    *Cluster              `xml:"cluster"`
-	Comment                    string                `xml:"comment"`
+	Comment                    *string               `xml:"comment"`
 	Console                    *Console              `xml:"console"`
 	Cpu                        *Cpu                  `xml:"cpu"`
 	CpuProfile                 *CpuProfile           `xml:"cpu_profile"`
-	CpuShares                  int64                 `xml:"cpu_shares"`
+	CpuShares                  *int64                `xml:"cpu_shares"`
 	CreationTime               time.Time             `xml:"creation_time"`
 	CustomCompatibilityVersion *Version              `xml:"custom_compatibility_version"`
-	CustomCpuModel             string                `xml:"custom_cpu_model"`
-	CustomEmulatedMachine      string                `xml:"custom_emulated_machine"`
+	CustomCpuModel             *string               `xml:"custom_cpu_model"`
+	CustomEmulatedMachine      *string               `xml:"custom_emulated_machine"`
 	CustomProperties           []CustomProperty      `xml:"custom_properties"`
-	DeleteProtected            bool                  `xml:"delete_protected"`
-	Description                string                `xml:"description"`
+	DeleteProtected            *bool                 `xml:"delete_protected"`
+	Description                *string               `xml:"description"`
 	DiskAttachments            []DiskAttachment      `xml:"disk_attachments"`
 	Display                    *Display              `xml:"display"`
 	Domain                     *Domain               `xml:"domain"`
 	ExternalHostProvider       *ExternalHostProvider `xml:"external_host_provider"`
 	Floppies                   []Floppy              `xml:"floppies"`
-	Fqdn                       string                `xml:"fqdn"`
+	Fqdn                       *string               `xml:"fqdn"`
 	GraphicsConsoles           []GraphicsConsole     `xml:"graphics_consoles"`
 	GuestOperatingSystem       *GuestOperatingSystem `xml:"guest_operating_system"`
 	GuestTimeZone              *TimeZone             `xml:"guest_time_zone"`
 	HighAvailability           *HighAvailability     `xml:"high_availability"`
 	Host                       *Host                 `xml:"host"`
 	HostDevices                []HostDevice          `xml:"host_devices"`
-	Id                         string                `xml:"id,attr"`
+	Id                         *string               `xml:"id,attr"`
 	Initialization             *Initialization       `xml:"initialization"`
 	InstanceType               *InstanceType         `xml:"instance_type"`
 	Io                         *Io                   `xml:"io"`
 	KatelloErrata              []KatelloErratum      `xml:"katello_errata"`
 	LargeIcon                  *Icon                 `xml:"large_icon"`
 	Lease                      *StorageDomainLease   `xml:"lease"`
-	Memory                     int64                 `xml:"memory"`
+	Memory                     *int64                `xml:"memory"`
 	MemoryPolicy               *MemoryPolicy         `xml:"memory_policy"`
 	Migration                  *MigrationOptions     `xml:"migration"`
-	MigrationDowntime          int64                 `xml:"migration_downtime"`
-	Name                       string                `xml:"name"`
-	NextRunConfigurationExists bool                  `xml:"next_run_configuration_exists"`
+	MigrationDowntime          *int64                `xml:"migration_downtime"`
+	Name                       *string               `xml:"name"`
+	NextRunConfigurationExists *bool                 `xml:"next_run_configuration_exists"`
 	Nics                       []Nic                 `xml:"nics"`
 	NumaNodes                  []NumaNode            `xml:"numa_nodes"`
 	NumaTuneMode               NumaTuneMode          `xml:"numa_tune_mode"`
-	Origin                     string                `xml:"origin"`
+	Origin                     *string               `xml:"origin"`
 	OriginalTemplate           *Template             `xml:"original_template"`
 	Os                         *OperatingSystem      `xml:"os"`
 	Payloads                   []Payload             `xml:"payloads"`
@@ -3328,29 +3328,29 @@ type Vm struct {
 	Quota                      *Quota                `xml:"quota"`
 	ReportedDevices            []ReportedDevice      `xml:"reported_devices"`
 	RngDevice                  *RngDevice            `xml:"rng_device"`
-	RunOnce                    bool                  `xml:"run_once"`
+	RunOnce                    *bool                 `xml:"run_once"`
 	SerialNumber               *SerialNumber         `xml:"serial_number"`
 	Sessions                   []Session             `xml:"sessions"`
 	SmallIcon                  *Icon                 `xml:"small_icon"`
 	Snapshots                  []Snapshot            `xml:"snapshots"`
-	SoundcardEnabled           bool                  `xml:"soundcard_enabled"`
+	SoundcardEnabled           *bool                 `xml:"soundcard_enabled"`
 	Sso                        *Sso                  `xml:"sso"`
-	StartPaused                bool                  `xml:"start_paused"`
+	StartPaused                *bool                 `xml:"start_paused"`
 	StartTime                  time.Time             `xml:"start_time"`
-	Stateless                  bool                  `xml:"stateless"`
+	Stateless                  *bool                 `xml:"stateless"`
 	Statistics                 []Statistic           `xml:"statistics"`
 	Status                     VmStatus              `xml:"status"`
-	StatusDetail               string                `xml:"status_detail"`
-	StopReason                 string                `xml:"stop_reason"`
+	StatusDetail               *string               `xml:"status_detail"`
+	StopReason                 *string               `xml:"stop_reason"`
 	StopTime                   time.Time             `xml:"stop_time"`
 	StorageDomain              *StorageDomain        `xml:"storage_domain"`
 	Tags                       []Tag                 `xml:"tags"`
 	Template                   *Template             `xml:"template"`
 	TimeZone                   *TimeZone             `xml:"time_zone"`
-	TunnelMigration            bool                  `xml:"tunnel_migration"`
+	TunnelMigration            *bool                 `xml:"tunnel_migration"`
 	Type                       VmType                `xml:"type"`
 	Usb                        *Usb                  `xml:"usb"`
-	UseLatestTemplateVersion   bool                  `xml:"use_latest_template_version"`
+	UseLatestTemplateVersion   *bool                 `xml:"use_latest_template_version"`
 	VirtioScsi                 *VirtioScsi           `xml:"virtio_scsi"`
 	VmPool                     *VmPool               `xml:"vm_pool"`
 	Watchdogs                  []Watchdog            `xml:"watchdogs"`
@@ -3364,12 +3364,12 @@ type Watchdogs struct {
 type Watchdog struct {
 	OvStruct
 	Action       WatchdogAction `xml:"action"`
-	Comment      string         `xml:"comment"`
-	Description  string         `xml:"description"`
-	Id           string         `xml:"id,attr"`
+	Comment      *string        `xml:"comment"`
+	Description  *string        `xml:"description"`
+	Id           *string        `xml:"id,attr"`
 	InstanceType *InstanceType  `xml:"instance_type"`
 	Model        WatchdogModel  `xml:"model"`
-	Name         string         `xml:"name"`
+	Name         *string        `xml:"name"`
 	Template     *Template      `xml:"template"`
 	Vm           *Vm            `xml:"vm"`
 	Vms          []Vm           `xml:"vms"`
@@ -3382,12 +3382,12 @@ type Cdroms struct {
 
 type Cdrom struct {
 	OvStruct
-	Comment      string        `xml:"comment"`
-	Description  string        `xml:"description"`
+	Comment      *string       `xml:"comment"`
+	Description  *string       `xml:"description"`
 	File         *File         `xml:"file"`
-	Id           string        `xml:"id,attr"`
+	Id           *string       `xml:"id,attr"`
 	InstanceType *InstanceType `xml:"instance_type"`
-	Name         string        `xml:"name"`
+	Name         *string       `xml:"name"`
 	Template     *Template     `xml:"template"`
 	Vm           *Vm           `xml:"vm"`
 	Vms          []Vm          `xml:"vms"`
@@ -3400,21 +3400,21 @@ type ExternalHostProviders struct {
 
 type ExternalHostProvider struct {
 	OvStruct
-	AuthenticationUrl      string                    `xml:"authentication_url"`
+	AuthenticationUrl      *string                   `xml:"authentication_url"`
 	Certificates           []Certificate             `xml:"certificates"`
-	Comment                string                    `xml:"comment"`
+	Comment                *string                   `xml:"comment"`
 	ComputeResources       []ExternalComputeResource `xml:"compute_resources"`
-	Description            string                    `xml:"description"`
+	Description            *string                   `xml:"description"`
 	DiscoveredHosts        []ExternalDiscoveredHost  `xml:"discovered_hosts"`
 	HostGroups             []ExternalHostGroup       `xml:"host_groups"`
 	Hosts                  []Host                    `xml:"hosts"`
-	Id                     string                    `xml:"id,attr"`
-	Name                   string                    `xml:"name"`
-	Password               string                    `xml:"password"`
+	Id                     *string                   `xml:"id,attr"`
+	Name                   *string                   `xml:"name"`
+	Password               *string                   `xml:"password"`
 	Properties             []Property                `xml:"properties"`
-	RequiresAuthentication bool                      `xml:"requires_authentication"`
-	Url                    string                    `xml:"url"`
-	Username               string                    `xml:"username"`
+	RequiresAuthentication *bool                     `xml:"requires_authentication"`
+	Url                    *string                   `xml:"url"`
+	Username               *string                   `xml:"username"`
 }
 
 type GlusterBricks struct {
@@ -3424,21 +3424,21 @@ type GlusterBricks struct {
 
 type GlusterBrick struct {
 	OvStruct
-	BrickDir       string              `xml:"brick_dir"`
-	Comment        string              `xml:"comment"`
-	Description    string              `xml:"description"`
-	Device         string              `xml:"device"`
-	FsName         string              `xml:"fs_name"`
+	BrickDir       *string             `xml:"brick_dir"`
+	Comment        *string             `xml:"comment"`
+	Description    *string             `xml:"description"`
+	Device         *string             `xml:"device"`
+	FsName         *string             `xml:"fs_name"`
 	GlusterClients []GlusterClient     `xml:"gluster_clients"`
 	GlusterVolume  *GlusterVolume      `xml:"gluster_volume"`
-	Id             string              `xml:"id,attr"`
+	Id             *string             `xml:"id,attr"`
 	InstanceType   *InstanceType       `xml:"instance_type"`
 	MemoryPools    []GlusterMemoryPool `xml:"memory_pools"`
-	MntOptions     string              `xml:"mnt_options"`
-	Name           string              `xml:"name"`
-	Pid            int64               `xml:"pid"`
-	Port           int64               `xml:"port"`
-	ServerId       string              `xml:"server_id"`
+	MntOptions     *string             `xml:"mnt_options"`
+	Name           *string             `xml:"name"`
+	Pid            *int64              `xml:"pid"`
+	Port           *int64              `xml:"port"`
+	ServerId       *string             `xml:"server_id"`
 	Statistics     []Statistic         `xml:"statistics"`
 	Status         GlusterBrickStatus  `xml:"status"`
 	Template       *Template           `xml:"template"`
@@ -3456,50 +3456,50 @@ type InstanceType struct {
 	Bios                       *Bios               `xml:"bios"`
 	Cdroms                     []Cdrom             `xml:"cdroms"`
 	Cluster                    *Cluster            `xml:"cluster"`
-	Comment                    string              `xml:"comment"`
+	Comment                    *string             `xml:"comment"`
 	Console                    *Console            `xml:"console"`
 	Cpu                        *Cpu                `xml:"cpu"`
 	CpuProfile                 *CpuProfile         `xml:"cpu_profile"`
-	CpuShares                  int64               `xml:"cpu_shares"`
+	CpuShares                  *int64              `xml:"cpu_shares"`
 	CreationTime               time.Time           `xml:"creation_time"`
 	CustomCompatibilityVersion *Version            `xml:"custom_compatibility_version"`
-	CustomCpuModel             string              `xml:"custom_cpu_model"`
-	CustomEmulatedMachine      string              `xml:"custom_emulated_machine"`
+	CustomCpuModel             *string             `xml:"custom_cpu_model"`
+	CustomEmulatedMachine      *string             `xml:"custom_emulated_machine"`
 	CustomProperties           []CustomProperty    `xml:"custom_properties"`
-	DeleteProtected            bool                `xml:"delete_protected"`
-	Description                string              `xml:"description"`
+	DeleteProtected            *bool               `xml:"delete_protected"`
+	Description                *string             `xml:"description"`
 	DiskAttachments            []DiskAttachment    `xml:"disk_attachments"`
 	Display                    *Display            `xml:"display"`
 	Domain                     *Domain             `xml:"domain"`
 	GraphicsConsoles           []GraphicsConsole   `xml:"graphics_consoles"`
 	HighAvailability           *HighAvailability   `xml:"high_availability"`
-	Id                         string              `xml:"id,attr"`
+	Id                         *string             `xml:"id,attr"`
 	Initialization             *Initialization     `xml:"initialization"`
 	Io                         *Io                 `xml:"io"`
 	LargeIcon                  *Icon               `xml:"large_icon"`
 	Lease                      *StorageDomainLease `xml:"lease"`
-	Memory                     int64               `xml:"memory"`
+	Memory                     *int64              `xml:"memory"`
 	MemoryPolicy               *MemoryPolicy       `xml:"memory_policy"`
 	Migration                  *MigrationOptions   `xml:"migration"`
-	MigrationDowntime          int64               `xml:"migration_downtime"`
-	Name                       string              `xml:"name"`
+	MigrationDowntime          *int64              `xml:"migration_downtime"`
+	Name                       *string             `xml:"name"`
 	Nics                       []Nic               `xml:"nics"`
-	Origin                     string              `xml:"origin"`
+	Origin                     *string             `xml:"origin"`
 	Os                         *OperatingSystem    `xml:"os"`
 	Permissions                []Permission        `xml:"permissions"`
 	Quota                      *Quota              `xml:"quota"`
 	RngDevice                  *RngDevice          `xml:"rng_device"`
 	SerialNumber               *SerialNumber       `xml:"serial_number"`
 	SmallIcon                  *Icon               `xml:"small_icon"`
-	SoundcardEnabled           bool                `xml:"soundcard_enabled"`
+	SoundcardEnabled           *bool               `xml:"soundcard_enabled"`
 	Sso                        *Sso                `xml:"sso"`
-	StartPaused                bool                `xml:"start_paused"`
-	Stateless                  bool                `xml:"stateless"`
+	StartPaused                *bool               `xml:"start_paused"`
+	Stateless                  *bool               `xml:"stateless"`
 	Status                     TemplateStatus      `xml:"status"`
 	StorageDomain              *StorageDomain      `xml:"storage_domain"`
 	Tags                       []Tag               `xml:"tags"`
 	TimeZone                   *TimeZone           `xml:"time_zone"`
-	TunnelMigration            bool                `xml:"tunnel_migration"`
+	TunnelMigration            *bool               `xml:"tunnel_migration"`
 	Type                       VmType              `xml:"type"`
 	Usb                        *Usb                `xml:"usb"`
 	Version                    *TemplateVersion    `xml:"version"`
@@ -3515,19 +3515,19 @@ type OpenStackImageProviders struct {
 
 type OpenStackImageProvider struct {
 	OvStruct
-	AuthenticationUrl      string           `xml:"authentication_url"`
+	AuthenticationUrl      *string          `xml:"authentication_url"`
 	Certificates           []Certificate    `xml:"certificates"`
-	Comment                string           `xml:"comment"`
-	Description            string           `xml:"description"`
-	Id                     string           `xml:"id,attr"`
+	Comment                *string          `xml:"comment"`
+	Description            *string          `xml:"description"`
+	Id                     *string          `xml:"id,attr"`
 	Images                 []OpenStackImage `xml:"images"`
-	Name                   string           `xml:"name"`
-	Password               string           `xml:"password"`
+	Name                   *string          `xml:"name"`
+	Password               *string          `xml:"password"`
 	Properties             []Property       `xml:"properties"`
-	RequiresAuthentication bool             `xml:"requires_authentication"`
-	TenantName             string           `xml:"tenant_name"`
-	Url                    string           `xml:"url"`
-	Username               string           `xml:"username"`
+	RequiresAuthentication *bool            `xml:"requires_authentication"`
+	TenantName             *string          `xml:"tenant_name"`
+	Url                    *string          `xml:"url"`
+	Username               *string          `xml:"username"`
 }
 
 type OpenStackNetworkProviders struct {
@@ -3538,23 +3538,23 @@ type OpenStackNetworkProviders struct {
 type OpenStackNetworkProvider struct {
 	OvStruct
 	AgentConfiguration     *AgentConfiguration          `xml:"agent_configuration"`
-	AuthenticationUrl      string                       `xml:"authentication_url"`
+	AuthenticationUrl      *string                      `xml:"authentication_url"`
 	Certificates           []Certificate                `xml:"certificates"`
-	Comment                string                       `xml:"comment"`
-	Description            string                       `xml:"description"`
-	Id                     string                       `xml:"id,attr"`
-	Name                   string                       `xml:"name"`
+	Comment                *string                      `xml:"comment"`
+	Description            *string                      `xml:"description"`
+	Id                     *string                      `xml:"id,attr"`
+	Name                   *string                      `xml:"name"`
 	Networks               []OpenStackNetwork           `xml:"networks"`
-	Password               string                       `xml:"password"`
+	Password               *string                      `xml:"password"`
 	PluginType             NetworkPluginType            `xml:"plugin_type"`
 	Properties             []Property                   `xml:"properties"`
-	ReadOnly               bool                         `xml:"read_only"`
-	RequiresAuthentication bool                         `xml:"requires_authentication"`
+	ReadOnly               *bool                        `xml:"read_only"`
+	RequiresAuthentication *bool                        `xml:"requires_authentication"`
 	Subnets                []OpenStackSubnet            `xml:"subnets"`
-	TenantName             string                       `xml:"tenant_name"`
+	TenantName             *string                      `xml:"tenant_name"`
 	Type                   OpenStackNetworkProviderType `xml:"type"`
-	Url                    string                       `xml:"url"`
-	Username               string                       `xml:"username"`
+	Url                    *string                      `xml:"url"`
+	Username               *string                      `xml:"username"`
 }
 
 type Snapshots struct {
@@ -3569,82 +3569,82 @@ type Snapshot struct {
 	Bios                       *Bios                 `xml:"bios"`
 	Cdroms                     []Cdrom               `xml:"cdroms"`
 	Cluster                    *Cluster              `xml:"cluster"`
-	Comment                    string                `xml:"comment"`
+	Comment                    *string               `xml:"comment"`
 	Console                    *Console              `xml:"console"`
 	Cpu                        *Cpu                  `xml:"cpu"`
 	CpuProfile                 *CpuProfile           `xml:"cpu_profile"`
-	CpuShares                  int64                 `xml:"cpu_shares"`
+	CpuShares                  *int64                `xml:"cpu_shares"`
 	CreationTime               time.Time             `xml:"creation_time"`
 	CustomCompatibilityVersion *Version              `xml:"custom_compatibility_version"`
-	CustomCpuModel             string                `xml:"custom_cpu_model"`
-	CustomEmulatedMachine      string                `xml:"custom_emulated_machine"`
+	CustomCpuModel             *string               `xml:"custom_cpu_model"`
+	CustomEmulatedMachine      *string               `xml:"custom_emulated_machine"`
 	CustomProperties           []CustomProperty      `xml:"custom_properties"`
 	Date                       time.Time             `xml:"date"`
-	DeleteProtected            bool                  `xml:"delete_protected"`
-	Description                string                `xml:"description"`
+	DeleteProtected            *bool                 `xml:"delete_protected"`
+	Description                *string               `xml:"description"`
 	DiskAttachments            []DiskAttachment      `xml:"disk_attachments"`
 	Display                    *Display              `xml:"display"`
 	Domain                     *Domain               `xml:"domain"`
 	ExternalHostProvider       *ExternalHostProvider `xml:"external_host_provider"`
 	Floppies                   []Floppy              `xml:"floppies"`
-	Fqdn                       string                `xml:"fqdn"`
+	Fqdn                       *string               `xml:"fqdn"`
 	GraphicsConsoles           []GraphicsConsole     `xml:"graphics_consoles"`
 	GuestOperatingSystem       *GuestOperatingSystem `xml:"guest_operating_system"`
 	GuestTimeZone              *TimeZone             `xml:"guest_time_zone"`
 	HighAvailability           *HighAvailability     `xml:"high_availability"`
 	Host                       *Host                 `xml:"host"`
 	HostDevices                []HostDevice          `xml:"host_devices"`
-	Id                         string                `xml:"id,attr"`
+	Id                         *string               `xml:"id,attr"`
 	Initialization             *Initialization       `xml:"initialization"`
 	InstanceType               *InstanceType         `xml:"instance_type"`
 	Io                         *Io                   `xml:"io"`
 	KatelloErrata              []KatelloErratum      `xml:"katello_errata"`
 	LargeIcon                  *Icon                 `xml:"large_icon"`
 	Lease                      *StorageDomainLease   `xml:"lease"`
-	Memory                     int64                 `xml:"memory"`
+	Memory                     *int64                `xml:"memory"`
 	MemoryPolicy               *MemoryPolicy         `xml:"memory_policy"`
 	Migration                  *MigrationOptions     `xml:"migration"`
-	MigrationDowntime          int64                 `xml:"migration_downtime"`
-	Name                       string                `xml:"name"`
-	NextRunConfigurationExists bool                  `xml:"next_run_configuration_exists"`
+	MigrationDowntime          *int64                `xml:"migration_downtime"`
+	Name                       *string               `xml:"name"`
+	NextRunConfigurationExists *bool                 `xml:"next_run_configuration_exists"`
 	Nics                       []Nic                 `xml:"nics"`
 	NumaNodes                  []NumaNode            `xml:"numa_nodes"`
 	NumaTuneMode               NumaTuneMode          `xml:"numa_tune_mode"`
-	Origin                     string                `xml:"origin"`
+	Origin                     *string               `xml:"origin"`
 	OriginalTemplate           *Template             `xml:"original_template"`
 	Os                         *OperatingSystem      `xml:"os"`
 	Payloads                   []Payload             `xml:"payloads"`
 	Permissions                []Permission          `xml:"permissions"`
-	PersistMemorystate         bool                  `xml:"persist_memorystate"`
+	PersistMemorystate         *bool                 `xml:"persist_memorystate"`
 	PlacementPolicy            *VmPlacementPolicy    `xml:"placement_policy"`
 	Quota                      *Quota                `xml:"quota"`
 	ReportedDevices            []ReportedDevice      `xml:"reported_devices"`
 	RngDevice                  *RngDevice            `xml:"rng_device"`
-	RunOnce                    bool                  `xml:"run_once"`
+	RunOnce                    *bool                 `xml:"run_once"`
 	SerialNumber               *SerialNumber         `xml:"serial_number"`
 	Sessions                   []Session             `xml:"sessions"`
 	SmallIcon                  *Icon                 `xml:"small_icon"`
 	SnapshotStatus             SnapshotStatus        `xml:"snapshot_status"`
 	SnapshotType               SnapshotType          `xml:"snapshot_type"`
 	Snapshots                  []Snapshot            `xml:"snapshots"`
-	SoundcardEnabled           bool                  `xml:"soundcard_enabled"`
+	SoundcardEnabled           *bool                 `xml:"soundcard_enabled"`
 	Sso                        *Sso                  `xml:"sso"`
-	StartPaused                bool                  `xml:"start_paused"`
+	StartPaused                *bool                 `xml:"start_paused"`
 	StartTime                  time.Time             `xml:"start_time"`
-	Stateless                  bool                  `xml:"stateless"`
+	Stateless                  *bool                 `xml:"stateless"`
 	Statistics                 []Statistic           `xml:"statistics"`
 	Status                     VmStatus              `xml:"status"`
-	StatusDetail               string                `xml:"status_detail"`
-	StopReason                 string                `xml:"stop_reason"`
+	StatusDetail               *string               `xml:"status_detail"`
+	StopReason                 *string               `xml:"stop_reason"`
 	StopTime                   time.Time             `xml:"stop_time"`
 	StorageDomain              *StorageDomain        `xml:"storage_domain"`
 	Tags                       []Tag                 `xml:"tags"`
 	Template                   *Template             `xml:"template"`
 	TimeZone                   *TimeZone             `xml:"time_zone"`
-	TunnelMigration            bool                  `xml:"tunnel_migration"`
+	TunnelMigration            *bool                 `xml:"tunnel_migration"`
 	Type                       VmType                `xml:"type"`
 	Usb                        *Usb                  `xml:"usb"`
-	UseLatestTemplateVersion   bool                  `xml:"use_latest_template_version"`
+	UseLatestTemplateVersion   *bool                 `xml:"use_latest_template_version"`
 	VirtioScsi                 *VirtioScsi           `xml:"virtio_scsi"`
 	Vm                         *Vm                   `xml:"vm"`
 	VmPool                     *VmPool               `xml:"vm_pool"`


### PR DESCRIPTION
In contrast to former primitive type of struct members, the new pointer type could be recognized if the member value exists after xml un-marshaling.