### PR TITLE
Add missing imports and remove goimports dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,6 @@ oVirt Engine API.
 You must install the Go binary and setup the Go environments, including
 `GOROOT` and `GOPATH`.
 
-The build phrase (using maven) uses `goimports` to format the generated 
-codes, so you must install it as following:
-```bash
-$ go get -u -v golang.org/x/tools/cmd/goimports
-```
-
 Most of the source code of the Go SDK is automatically generated
 from the API model (Java).
 

--- a/generator/src/main/java/org/ovirt/sdk/go/TypesGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/TypesGenerator.java
@@ -109,6 +109,7 @@ public class TypesGenerator implements GoGenerator {
         // Customize type generation
         //      Add  Error method for type Fault
         buffer.addLine();
+        buffer.addImport("fmt");
         buffer.addLine("func (fault *Fault) Error() string {");
         buffer.addLine(  "return fmt.Sprintf(\"Error details is %%s, reason is %%s\", fault.Detail, fault.Reason)");
         buffer.addLine("}");
@@ -121,6 +122,7 @@ public class TypesGenerator implements GoGenerator {
         // Define []Struct
         buffer.addLine("type %1$ss struct {", typeName.getClassName());
         //  Add xml.Name
+        buffer.addImport("encoding/xml");
         buffer.addLine(  "XMLName xml.Name `xml:\"%1$ss\"`", typeName.getClassName().toLowerCase());
         buffer.addLine(  "%1$ss []%1$s `xml:\"%2$s,omitempty\"`", typeName.getClassName(), goNames.getTagStyleName(type.getName()));
         buffer.addLine("}");

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -101,22 +101,6 @@ limitations under the License.
             </configuration>
           </execution>
 
-          <!-- Run code format by goimports -->
-          <execution>
-            <id>goimports-format</id>
-            <phase>package</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <executable>goimports</executable>
-              <arguments>
-                <argument>-w</argument>
-                <argument>ovirtsdk4</argument>
-              </arguments>
-            </configuration>
-          </execution>
-
           <!-- Run the tests: -->
           <execution>
             <id>test</id>


### PR DESCRIPTION
This change adds the missing imports of `encoding/xml` and `fmt` packages, removes the `goimports` dependency to format codes. The `goimports` covers up the missing of imports bug.