### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+
+install: true
+
+script: mvn package -DskipTests

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -101,6 +101,23 @@ limitations under the License.
             </configuration>
           </execution>
 
+          <!-- Compile the Go code: -->
+          <execution>
+            <id>compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>${go.command}</executable>
+              <arguments>
+                <argument>build</argument>
+                <argument>-v</argument>
+                <argument>./ovirtsdk4</argument>
+              </arguments>
+            </configuration>
+          </execution>
+
           <!-- Run the tests: -->
           <execution>
             <id>test</id>


### PR DESCRIPTION
This patch modifies the POM file of the SDK so that during the compile
phase it compiles all the Go source code. Then it adds a .travis.yml
file so that this compilation will be also done in Travis CI.

Note that the .travis.yml file is currently configured to skip the
tests, because one of the tests tries to use HTTP communication to an
oVirt engine server, which will always fail in the Travis CI
environment.