### PR TITLE
Remove auto-generated codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ target/
 .vscode/
 .project
 
+# Auto-generated files
+sdk/ovirtsdk4/services.go
+sdk/ovirtsdk4/types.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,10 @@ language: java
 install: true
 
 script: mvn package -DskipTests
+
+after_success:
+  - ./.travis/deploy-codes.sh
+
+env:
+  global:
+    secure: SNjA7QGcgwE4oEFJO5nghPrOe2SSXtudR031lB4vFGJdSMg5aBKzTYc5/ejFKcW5SkDC5+3N1M5JScAdL9UEO+A2mY5494p3X4ORqjbCpUTfnGJEwUeX4SXHL5t8yLJ2pPDlBnNx9H0PjHjduZIZywha4FSeCzvf71kB2QtqkwCGyH8lmi3aFziwFu5oO9OgyPg+jjMmmWHQ3az/v0Ini+hPXw1ZHsFy66VHHpUpUMD/sN7/S526D8lX0FUoYtHfBmMlg8x6J5gAqSLTX6whR+r3xT4QmHZyJZWzatlQ2GxlDbld2hhDmf8bpq8V6heAv1wHePRSuf1k2X6Tx6zOro3VPS00kZYuUsPr1w2vrgamjd8SwhD6lEpPjZXb2d4gN1VA/maBR70UTiA8+Gok/ioNs6C1jUkTrXXohWw/CxcEfmHURMVXYbEkyXZljOyxgj2lmflFUnH22hGRi79mkSq1GHUrIAyAQTYcQ4cVUW2Y/2MUxW1NP9kFqHfi31oGwxoZYvTyTYTiNs9Ulz+xz7FlpgOJia2P8/xg7qZA4fsG1HC5K3E0HJJK7hd6Fe9V4SsWYvcRk65h8fUitvaqWZo+klRLF6nWSa1wEv0XqbxbXj02mZGMNCAHZCd+zm912RzEoXkwym6LKfO/f6i6URGZTpQ7rSKO1L/gRo6/mJg=

--- a/.travis/deploy-codes.sh
+++ b/.travis/deploy-codes.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Pull requests and commits to other branches shouldn't try to deploy
+if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "master" ]; then
+    echo "Skipping deploy codes"
+    exit 0
+fi
+
+cd ./sdk/ovirtsdk4/
+
+git init
+
+git config --global user.email "travis@travis-ci.org"
+git config --global user.name "Travis CI"
+
+git remote add origin https://${GH_TOKEN}@github.com/imjoey/go-ovirt.git
+
+git add -A 
+
+git commit --message "Generator commit ID: ${TRAVIS_COMMIT:0:7} with message: $TRAVIS_COMMIT_MESSAGE. Travis build: $TRAVIS_BUILD_NUMBER."
+
+git push -f --quiet --set-upstream origin master

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # oVirt Go SDK [![Build Status](https://travis-ci.org/imjoey/ovirt-engine-sdk-go.svg?branch=master)](https://travis-ci.org/imjoey/ovirt-engine-sdk-go)
 
-Go SDK for oVirt 4.0+, main functions are finished, excluding error processing...
-
-Project completion is almost 80%.
 
 ## Introduction
 
 The oVirt Go SDK is a Go package that simplyfies access to the
 oVirt Engine API.
+
+> IMPORTANT: This document describes how to generate, build and test the
+SDK. If you are interested in how to use it read the `README.md` file
+in the [imjoey/go-ovirt](https://github.com/imjoey/go-ovirt) repository instead.
 
 ## Building
 
@@ -46,56 +47,3 @@ If you wish to use a different version of Go you can use the
 ```bash
 $ mvn package -Dgo.command=go1.7
 ```
-
-## Usage
-
-To use the SDK you should import ovirtsdk4 package as follows:
-```go
-import (
-    "github.com/imjoey/ovirt-engine-sdk-go/sdk/ovirtsdk4"
-)
-```
-
-That will give you access to all the classes of the SDK, and in particular
-to the `Connection` class. This is the entry point of the SDK,
-and gives you access to the root of the tree of services of the API:
-
-```go
-// Create a connection to the server:
-import (
-    "time"
-    "github.com/imjoey/ovirt-engine-sdk-go/sdk/ovirtsdk4"
-)
-
-inputRawURL := "https://10.1.111.229/ovirt-engine/api"
-conn, err := NewConnectionBuilder().
-	URL(inputRawURL).
-	Username("admin@internal").
-	Password("qwer1234").
-	Insecure(true).
-	Compress(true).
-	Timeout(time.Second * 10).
-	Build()
-if err != nil {
-	t.Fatalf("Make connection failed, reason: %s", err.Error())
-}
-
-defer conn.Close()
-
-clustersListResponse, err2 := conn.SystemService().ClustersService().
-	List().
-	CaseSensitive(false).
-	Max(100).
-	Send()
-
-if err2 != nil {
-	t.Fatalf("Get clusters failed, reason: %s", err2.Error())
-}
-
-for _, cluster := range clustersListResponse.Clusters() {
-	t.Logf("cluster(%v): CPU architecture is %v and type is %v", *cluster.Id,cluster.Cpu.Architecture, *cluster.Cpu.Type)
-}
-
-```
-
-For more usage examples, you could refer to [sdk/README](https://github.com/imjoey/ovirt-engine-sdk-go/blob/master/sdk/README.md).

--- a/sdk/ovirtsdk4/README.md
+++ b/sdk/ovirtsdk4/README.md
@@ -1,0 +1,60 @@
+# oVirt Go SDK [![Build Status](https://travis-ci.org/imjoey/ovirt-engine-sdk-go.svg?branch=master)](https://travis-ci.org/imjoey/ovirt-engine-sdk-go)
+
+## Introduction
+
+The oVirt Go SDK is a Go package that simplyfies access to the
+oVirt Engine API.
+
+> IMPORTANT: The code in this project is generated automatically by the [imjoey/ovirt-engine-sdk-go](https://github.com/imjoey/ovirt-engine-sdk-go). So if you want to know how to generate the code, please read the `README.md` in the  [imjoey/ovirt-engine-sdk-go](https://github.com/imjoey/ovirt-engine-sdk-go) repositorys instead.
+
+## Usage
+
+To use the SDK you should import ovirtsdk4 package as follows:
+
+```go
+import (
+    "github.com/imjoey/go-ovirt"
+)
+```
+
+That will give you access to all the classes of the SDK, and in particular
+to the `Connection` class. This is the entry point of the SDK,
+and gives you access to the root of the tree of services of the API:
+
+```go
+// Create a connection to the server:
+import (
+    "time"
+    "github.com/imjoey/go-ovirt"
+)
+
+inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+conn, err := ovirtsdk4.NewConnectionBuilder().
+	URL(inputRawURL).
+	Username("admin@internal").
+	Password("qwer1234").
+	Insecure(true).
+	Compress(true).
+	Timeout(time.Second * 10).
+	Build()
+if err != nil {
+	t.Fatalf("Make connection failed, reason: %s", err.Error())
+}
+
+defer conn.Close()
+
+clustersListResponse, err2 := conn.SystemService().ClustersService().
+	List().
+	CaseSensitive(false).
+	Max(100).
+	Send()
+
+if err2 != nil {
+	t.Fatalf("Get clusters failed, reason: %s", err2.Error())
+}
+
+for _, cluster := range clustersListResponse.Clusters() {
+	t.Logf("cluster(%v): CPU architecture is %v and type is %v", *cluster.Id,cluster.Cpu.Architecture, *cluster.Cpu.Type)
+}
+
+```

--- a/sdk/ovirtsdk4/connection_test.go
+++ b/sdk/ovirtsdk4/connection_test.go
@@ -20,7 +20,6 @@ func TestSend(t *testing.T) {
 		t.Fatalf("Make connection failed, reason: %s", err.Error())
 	}
 	defer conn.Close()
-
 	clustersListResponse, err2 := conn.SystemService().ClustersService().
 		List().
 		CaseSensitive(false).


### PR DESCRIPTION
Fixes #19 .

1. Removes the auto-generated sdk code in sdk/ovirtsdk4 directory.
2. Configs Travis CI (.tarvis-ci.yml) to push the sdk code back to imjoey/go-ovirt after success build.