### PR TITLE
Remove the Error() method of struct Fault in TypesGenerator.

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/go/TypesGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/TypesGenerator.java
@@ -94,14 +94,6 @@ public class TypesGenerator implements GoGenerator {
             .map(EnumType.class::cast)
             .sorted()
             .forEach(this::generateEnum);
-        
-        // Customize type generation
-        //      Add  Error method for type Fault
-        buffer.addLine();
-        buffer.addImport("fmt");
-        buffer.addLine("func (fault *Fault) Error() string {");
-        buffer.addLine(  "return fmt.Sprintf(\"Error details is %%s, reason is %%s\", fault.Detail, fault.Reason)");
-        buffer.addLine("}");
     }
 
     private void generateStruct(StructType type) {


### PR DESCRIPTION
Remove the unused Error() method of struct Fault in TypesGenerator.java after the refactor of Fault.