### PR TITLE
Copy the examples/ directory and push it into go-ovirt repository.

### DIFF
--- a/.travis/deploy-codes.sh
+++ b/.travis/deploy-codes.sh
@@ -10,6 +10,9 @@ cd ./sdk/ovirtsdk4/
 
 git init
 
+# Copy examples/ and push into go-ovirt repository
+cp -r ./sdk/examples ./
+
 git config --global user.email "travis@travis-ci.org"
 git config --global user.name "Travis CI"
 


### PR DESCRIPTION
Use the `cp` command to copy ./sdk/examples/ directory into ovirtsdk4/, and push it into go-ovirt repostiory, where the generated SDK codes locates.