### PR TITLE
Add setter and getter method for type members

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/go/GoTypes.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/GoTypes.java
@@ -81,6 +81,21 @@ public class GoTypes {
         return goNames.renameReserved(result);
     }
 
+    public String getMemberSetterMethodName(Name name) {
+        String result = name.words().map(words::capitalize).collect(joining());
+        return goNames.renameReserved("Set" + result);
+    }
+
+    public String getMemberGetterMethodName(Name name) {
+        String result = name.words().map(words::capitalize).collect(joining());
+        return goNames.renameReserved(result);
+    }
+
+    public String getMemberPresentMethodName(Name name) {
+        String result = name.words().map(words::capitalize).collect(joining());
+        return goNames.renameReserved(result + "Present");
+    }
+
     public Boolean isGoPrimitiveType(Type type) {
         if (type instanceof PrimitiveType) {
             if (type == type.getModel().getBooleanType() ||

--- a/sdk/examples/list_clusters.go
+++ b/sdk/examples/list_clusters.go
@@ -33,10 +33,17 @@ func main() {
 		return
 	}
 
-	// Print the datacenter names and identifiers:
-	for _, clu := range clustersResponse.Clusters() {
-		fmt.Printf("Cluster - (name: %v, id: %v)\n", *clu.Name, *clu.Id)
-		// fmt.Printf("Cluster is %+v\n", clu)
+	if clusters, ok := clustersResponse.Clusters(); ok {
+		// Print the datacenter names and identifiers:
+		fmt.Printf("Cluster: (")
+		for _, cluster := range clusters {
+			if clusterName, ok := cluster.Name(); ok {
+				fmt.Printf(" name: %v", clusterName)
+			}
+			if clusterId, ok := cluster.Id(); ok {
+				fmt.Printf(" id: %v", clusterId)
+			}
+		}
+		fmt.Println(")")
 	}
-
 }

--- a/sdk/examples/list_datacenters.go
+++ b/sdk/examples/list_datacenters.go
@@ -34,13 +34,27 @@ func main() {
 	}
 
 	// Print the datacenter names and identifiers:
-	for _, dc := range datacentersResponse.DataCenters() {
-		fmt.Printf("Datacenter - (name: %v, id: %v)\n", *dc.Name, *dc.Id)
-		fmt.Printf("  Supported versions are: ")
-		for _, sv := range dc.SupportedVersions {
-			fmt.Printf("(Major: %v, Minor: %v)  ", *sv.Major, *sv.Minor)
+	if datacenters, ok := datacentersResponse.DataCenters(); ok {
+		for _, dc := range datacenters {
+			fmt.Printf("Datacenter: ")
+			if dcName, ok := dc.Name(); ok {
+				fmt.Printf(" name: %v", dcName)
+			}
+			if dcId, ok := dc.Id(); ok {
+				fmt.Printf(" id: %v", dcId)
+			}
+			fmt.Printf("  Supported versions are: ")
+			if svs, ok := dc.SupportedVersions(); ok {
+				for _, sv := range svs {
+					if major, ok := sv.Major(); ok {
+						fmt.Printf(" Major: %v", major)
+					}
+					if minor, ok := sv.Minor(); ok {
+						fmt.Printf(" Minor: %v", minor)
+					}
+				}
+			}
+			fmt.Println("")
 		}
-		fmt.Println("")
 	}
-
 }

--- a/sdk/examples/list_vms.go
+++ b/sdk/examples/list_vms.go
@@ -33,9 +33,17 @@ func main() {
 		fmt.Printf("Failed to get vm list, reason: %v\n", err)
 		return
 	}
-
-	// Print the virtual machine names and identifiers:
-	for _, vm := range vmsResponse.Vms() {
-		fmt.Printf("VM - (name: %v, id: %v)\n", *vm.Name, *vm.Id)
+	if vms, ok := vmsResponse.Vms(); ok {
+		// Print the virtual machine names and identifiers:
+		for _, vm := range vms {
+			fmt.Print("VM: (")
+			if vmName, ok := vm.Name(); ok {
+				fmt.Printf(" name: %v", vmName)
+			}
+			if vmID, ok := vm.Id(); ok {
+				fmt.Printf(" id: %v", vmID)
+			}
+			fmt.Println(")")
+		}
 	}
 }

--- a/sdk/ovirtsdk4/readers_test.go
+++ b/sdk/ovirtsdk4/readers_test.go
@@ -86,32 +86,66 @@ func TestXMLClusterReadOne(t *testing.T) {
 
 	cluster, err := XMLClusterReadOne(reader, nil)
 	assert.Nil(err)
+
 	// Cluster>Id
 	// assert.Equal("00000002-0002-0002-0002-000000000310", *cluster.Id)
 	// Cluster>Name
-	assert.Equal("Default", *cluster.Name, "Name should be `Default`")
+	name, ok := cluster.Name()
+	assert.True(ok)
+	assert.Equal("Default", name, "Name should be `Default`")
+
 	// Cluster>CPU>Architecture
-	assert.NotNil(cluster.Cpu.Architecture)
-	assert.Equal(Architecture("x86_64"), *cluster.Cpu.Architecture, "CPU Arch should be `x86_64`")
+	cpu, ok := cluster.Cpu()
+	assert.True(ok)
+	arch, ok := cpu.Architecture()
+	assert.True(ok)
+	assert.Equal(Architecture("x86_64"), arch, "CPU Arch should be `x86_64`")
+
 	// Cluster>BallooningEnabled
-	assert.False(*cluster.BallooningEnabled, "Cluster>BallooningEnabled should be false")
+	ballooningEnabled, ok := cluster.BallooningEnabled()
+	assert.True(ok)
+	assert.False(ballooningEnabled, "Cluster>BallooningEnabled should be false")
+
 	// Cluster>Description
-	assert.Equal("The default server cluster", *cluster.Description)
+	desc, ok := cluster.Description()
+	assert.True(ok)
+	assert.Equal("The default server cluster", desc)
+
 	// Cluster>ErrorHandling>OnError>MigrateOnError
-	assert.NotNil(cluster.ErrorHandling, "Cluster>ErrorHandling should not be nil")
-	assert.NotNil(cluster.ErrorHandling.OnError)
-	assert.Equal(MigrateOnError("migrate"), *cluster.ErrorHandling.OnError)
+	errorHandling, ok := cluster.ErrorHandling()
+	assert.True(ok)
+	errorHandlingOnError, ok := errorHandling.OnError()
+	assert.Equal(MigrateOnError("migrate"), errorHandlingOnError)
+
 	// Cluster>FencingPolicy
-	assert.NotNil(*cluster.FencingPolicy)
+	fencingPolicy, ok := cluster.FencingPolicy()
+	assert.True(ok)
 	// 		>Enable
-	assert.True(*cluster.FencingPolicy.Enabled, "Cluster>FencingPolicy>Enable should be true")
+	fencingPolicyEnabled, ok := fencingPolicy.Enabled()
+	assert.True(ok)
+	assert.True(fencingPolicyEnabled, "Cluster>FencingPolicy>Enable should be true")
 	// 		>SkipIfConnectivityBroken>Threshold
-	assert.Equal(int64(50), *cluster.FencingPolicy.SkipIfConnectivityBroken.Threshold,
+	skipIfConnectiveBroken, ok := fencingPolicy.SkipIfConnectivityBroken()
+	assert.True(ok)
+	threshold, ok := skipIfConnectiveBroken.Threshold()
+	assert.True(ok)
+	assert.Equal(int64(50), threshold,
 		"Cluster>FencingPolicy>SkipIfConnectivityBroken>Threshold should be 50")
-	assert.False(*cluster.FencingPolicy.SkipIfSdActive.Enabled, "Cluster>FencingPolicy>SkipIfSdActive>Enabled should be false")
+	skipIfSdActive, ok := fencingPolicy.SkipIfSdActive()
+	assert.True(ok)
+	sdActiveEnable, ok := skipIfSdActive.Enabled()
+	assert.True(ok)
+	assert.False(sdActiveEnable, "Cluster>FencingPolicy>SkipIfSdActive>Enabled should be false")
+
 	// Cluster>SchedulingPolicy
-	assert.Equal("b4ed2332-a7ac-4d5f-9596-99a439cb2812", *cluster.SchedulingPolicy.Id)
-	assert.Equal("/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812", *cluster.SchedulingPolicy.Href)
+	schedulingPolicy, ok := cluster.SchedulingPolicy()
+	assert.True(ok)
+	schedulingPolicyID, ok := schedulingPolicy.Id()
+	assert.True(ok)
+	assert.Equal("b4ed2332-a7ac-4d5f-9596-99a439cb2812", schedulingPolicyID)
+	schedulingPolicyHref, ok := schedulingPolicy.Href()
+	assert.True(ok)
+	assert.Equal("/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812", schedulingPolicyHref)
 }
 
 func TestXMLErrorHandlingReadOne(t *testing.T) {
@@ -124,8 +158,9 @@ func TestXMLErrorHandlingReadOne(t *testing.T) {
 	eh, err := XMLErrorHandlingReadOne(reader, nil)
 	assert.Nil(err)
 	assert.NotNil(eh)
-	assert.NotNil(eh.OnError)
-	assert.Equal(MigrateOnError("migrate"), *eh.OnError)
+	onError, ok := eh.OnError()
+	assert.True(ok)
+	assert.Equal(MigrateOnError("migrate"), onError)
 }
 
 func TestXMLCPUReadOne(t *testing.T) {
@@ -141,9 +176,12 @@ func TestXMLCPUReadOne(t *testing.T) {
 
 	cpu, err := XMLCpuReadOne(reader, nil)
 	assert.Nil(err)
-	assert.NotNil(cpu.Architecture)
-	assert.Equal(Architecture("x86_64"), *cpu.Architecture)
-	assert.Equal("Intel SandyBridge Family", *cpu.Type)
+	cpuArch, ok := cpu.Architecture()
+	assert.True(ok)
+	assert.Equal(Architecture("x86_64"), cpuArch)
+	cpuType, ok := cpu.Type()
+	assert.True(ok)
+	assert.Equal("Intel SandyBridge Family", cpuType)
 }
 
 func TestArchitectureReadMany(t *testing.T) {

--- a/sdk/ovirtsdk4/service.go
+++ b/sdk/ovirtsdk4/service.go
@@ -71,8 +71,8 @@ func CheckAction(response *http.Response) (*Action, error) {
 		return nil, err
 	}
 	if action != nil {
-		if action.Fault != nil {
-			return nil, BuildError(response, action.Fault)
+		if afault, ok := action.Fault(); ok {
+			return nil, BuildError(response, afault)
 		}
 		return action, nil
 	}
@@ -83,17 +83,17 @@ func CheckAction(response *http.Response) (*Action, error) {
 func BuildError(response *http.Response, fault *Fault) error {
 	var buffer bytes.Buffer
 	if fault != nil {
-		if fault.Reason != nil {
+		if reason, ok := fault.Reason(); ok {
 			if buffer.Len() > 0 {
 				buffer.WriteString(" ")
 			}
-			buffer.WriteString(fmt.Sprintf("Fault reason is \"%s\".", *fault.Reason))
+			buffer.WriteString(fmt.Sprintf("Fault reason is \"%s\".", reason))
 		}
-		if fault.Detail != nil {
+		if detail, ok := fault.Detail(); ok {
 			if buffer.Len() > 0 {
 				buffer.WriteString(" ")
 			}
-			buffer.WriteString(fmt.Sprintf("Fault detail is \"%s\".", *fault.Detail))
+			buffer.WriteString(fmt.Sprintf("Fault detail is \"%s\".", detail))
 		}
 	}
 	if response != nil {

--- a/sdk/ovirtsdk4/type.go
+++ b/sdk/ovirtsdk4/type.go
@@ -18,11 +18,22 @@ package ovirtsdk4
 
 // Link represents struct of href and rel attributes
 type Link struct {
-	Href *string `xml:"href, attr"`
-	Rel  *string `xml:"rel, attr"`
+	href *string
+	rel  *string
 }
 
 // OvStruct represents the base for all struts defined in types.go
 type OvStruct struct {
-	Href *string `xml:"href, attr"`
+	href *string
+}
+
+func (p *OvStruct) Href() (string, bool) {
+	if p.href != nil {
+		return *p.href, true
+	}
+	return "", false
+}
+
+func (p *OvStruct) SetHref(attr string) {
+	p.href = &attr
 }


### PR DESCRIPTION
1. This fixes #4 . Add setter and getter method for type members. Use the second returned value of getter method to indicate if the member is present, instead of an explicit present method. This is more secure and more idiomatic in Go. The getter method is defined as blow:
```go
func (p *Vm) Name() (string, bool) {
	if p.name != nil {
		return *p.name, true
	}
	return "", false
}
```
When using this, callers should check the second value as blow:
```go
if vmName, ok := vm.Name(); ok {
	fmt.Printf(" name: %v", vmName)
}
```

2. Add the second returned value for the member getter methods in ServiceResponse, to indicate if the member is present, in case of range nil which cause panics. The new definition and calling way are same as the above.
