### PR TITLE
Add must getter methods for type structs and service responses.

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/go/GoTypes.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/GoTypes.java
@@ -91,6 +91,10 @@ public class GoTypes {
         return goNames.renameReserved(result);
     }
 
+    public String getMemberMustGetterMethodName(Name name) {
+        return "Must" + getMemberGetterMethodName(name);
+    }
+
     public String getMemberPresentMethodName(Name name) {
         String result = name.words().map(words::capitalize).collect(joining());
         return goNames.renameReserved(result + "Present");

--- a/generator/src/main/java/org/ovirt/sdk/go/TypesGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/TypesGenerator.java
@@ -174,6 +174,19 @@ public class TypesGenerator implements GoGenerator {
         }
         buffer.addLine("}");    // End of getter method
         buffer.addLine();
+        // Generate the MUST getter method
+        buffer.addLine("func (p *%1$s) %2$s() %3$s {",
+            structTypeName.getClassName(),
+            goTypes.getMemberMustGetterMethodName(member.getName()),
+            memberTypeRef.getText()
+        );
+        if (goTypes.isGoPrimitiveType(type) || type instanceof EnumType) {
+            buffer.addLine(" return *p.%1$s", goNames.getPrivateMemberStyleName(member.getName()));
+        } else {
+            buffer.addLine(" return p.%1$s", goNames.getPrivateMemberStyleName(member.getName()));
+        }
+        buffer.addLine("}");
+        buffer.addLine();
     }
 
     private void generateStructBuilder(StructType type) {

--- a/sdk/ovirtsdk4/type.go
+++ b/sdk/ovirtsdk4/type.go
@@ -34,6 +34,10 @@ func (p *OvStruct) Href() (string, bool) {
 	return "", false
 }
 
+func (p *OvStruct) MustHref() string {
+	return *p.href
+}
+
 func (p *OvStruct) SetHref(attr string) {
 	p.href = &attr
 }


### PR DESCRIPTION
The getter methods return two values, which the latter is to indicate if it exists. However the latter one may be not used at all, so in this pr I add the **MUST** version of getter methods, which return only the member value.