### PR TITLE
Assign isParsed to true when reading the href attribute

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/go/ReadersGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/ReadersGenerator.java
@@ -145,6 +145,7 @@ public class ReadersGenerator implements GoGenerator {
             }
             buffer.addLine("    case \"href\":");
             buffer.addLine("      builder.Href(value)");
+            buffer.addLine("      isParsed = true");
 	        buffer.addLine("  	}");
 	        buffer.addLine("  }");
         }


### PR DESCRIPTION
Set `isParsed = true` when reading the `href` attribute in XML.