### PR TITLE
Rename OvStruct to Struct.

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/go/TypesGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/TypesGenerator.java
@@ -109,7 +109,7 @@ public class TypesGenerator implements GoGenerator {
         // Define Struct
         buffer.addLine("type %1$s struct {", typeName.getClassName());
         // Ignore Base-class mixin, fill in all
-        buffer.addLine("OvStruct");
+        buffer.addLine("Struct");
 
         // Constructor with a named parameter for each attribute and link:
         Set<StructMember> allMembers = Stream.concat(type.attributes(), type.links())

--- a/sdk/ovirtsdk4/type.go
+++ b/sdk/ovirtsdk4/type.go
@@ -22,22 +22,22 @@ type Link struct {
 	rel  *string
 }
 
-// OvStruct represents the base for all struts defined in types.go
-type OvStruct struct {
+// Struct represents the base for all struts defined in types.go
+type Struct struct {
 	href *string
 }
 
-func (p *OvStruct) Href() (string, bool) {
+func (p *Struct) Href() (string, bool) {
 	if p.href != nil {
 		return *p.href, true
 	}
 	return "", false
 }
 
-func (p *OvStruct) MustHref() string {
+func (p *Struct) MustHref() string {
 	return *p.href
 }
 
-func (p *OvStruct) SetHref(attr string) {
+func (p *Struct) SetHref(attr string) {
 	p.href = &attr
 }


### PR DESCRIPTION
Rename OvStruct to Struct as the base class of all types. Fixes #46 .