### PR TITLE
Return specified error when parsing mismatch XML tags

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/go/ServicesGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/ServicesGenerator.java
@@ -618,7 +618,7 @@ public class ServicesGenerator implements GoGenerator {
             }
         }
         else if (type instanceof StructType) {
-            buffer.addLine("result, err := %1$s(reader, nil)", goTypes.getXmlReadOneFuncName(type));
+            buffer.addLine("result, err := %1$s(reader, nil, \"\")", goTypes.getXmlReadOneFuncName(type));
         } else if (type instanceof ListType) {
             ListType listype = (ListType) type;
             Type elementType = listype.getElementType();

--- a/sdk/ovirtsdk4/reader.go
+++ b/sdk/ovirtsdk4/reader.go
@@ -10,6 +10,17 @@ import (
 	"time"
 )
 
+// XMLTagNotMatchError indicates the error of XML tag
+// not matched when unmarshaling XML
+type XMLTagNotMatchError struct {
+	ActualTag   string
+	ExpectedTag string
+}
+
+func (err XMLTagNotMatchError) Error() string {
+	return fmt.Sprintf("Tag not matched: expect <%v> but got <%v>", err.ExpectedTag, err.ActualTag)
+}
+
 // CanForward indicates if Decoder has been finished
 func CanForward(tok xml.Token) (bool, error) {
 	switch tok.(type) {

--- a/sdk/ovirtsdk4/readers_test.go
+++ b/sdk/ovirtsdk4/readers_test.go
@@ -84,9 +84,9 @@ func TestXMLClusterReadOne(t *testing.T) {
 
 	reader := NewXMLReader([]byte(xmlstring))
 
-	cluster, err := XMLClusterReadOne(reader, nil)
+	cluster, err := XMLClusterReadOne(reader, nil, "")
 	assert.Nil(err)
-
+	assert.NotNil(cluster)
 	// Cluster>Id
 	// assert.Equal("00000002-0002-0002-0002-000000000310", *cluster.Id)
 	// Cluster>Name
@@ -155,7 +155,7 @@ func TestXMLErrorHandlingReadOne(t *testing.T) {
         <on_error>migrate</on_error>
 	</error_handling>`
 	reader := NewXMLReader([]byte(xmlstring))
-	eh, err := XMLErrorHandlingReadOne(reader, nil)
+	eh, err := XMLErrorHandlingReadOne(reader, nil, "")
 	assert.Nil(err)
 	assert.NotNil(eh)
 	onError, ok := eh.OnError()
@@ -174,7 +174,7 @@ func TestXMLCPUReadOne(t *testing.T) {
 
 	reader := NewXMLReader([]byte(xmlstring))
 
-	cpu, err := XMLCpuReadOne(reader, nil)
+	cpu, err := XMLCpuReadOne(reader, nil, "")
 	assert.Nil(err)
 	cpuArch, ok := cpu.Architecture()
 	assert.True(ok)
@@ -214,7 +214,10 @@ func TestFaultReadOne(t *testing.T) {
 	<architecture>powerpc</architecture>
 </architectures>`
 	reader := NewXMLReader([]byte(xmlstring))
-	fault, err := XMLFaultReadOne(reader, nil)
-	assert.Nil(err)
+	fault, err := XMLFaultReadOne(reader, nil, "")
 	assert.Nil(fault)
+	err2, ok := err.(XMLTagNotMatchError)
+	assert.True(ok)
+	assert.Equal("architectures", err2.ActualTag)
+	assert.Equal("fault", err2.ExpectedTag)
 }


### PR DESCRIPTION
Fixes #58 . When encountering a mismatch XML tag, change the `XMLReadOne` function returned value  to the new `XMLTagNotMatchError`.
```go
// XMLTagNotMatchError indicates the error of XML tag
// not matched when unmarshaling XML
type XMLTagNotMatchError struct {
	ActualTag   string
	ExpectedTag string
}

func (err XMLTagNotMatchError) Error() string {
	return fmt.Sprintf("Tag not matched: expect <%v> but got <%v>", err.ExpectedTag, err.ActualTag)
}
```

Then use the code below to determine if the XML is not match with the `XMLReadOne` function.
```go
fault, err := XMLFaultReadOne(reader, nil, "")
if err != nil {
	// If the XML is not a <fault>, just return nil
	if _, ok := err.(XMLTagNotMatchError); ok {
		return nil
	}
        return err
}
```