### PR TITLE
Import remote go-ovirt package instead of local directory in examples

### DIFF
--- a/sdk/examples/list_clusters.go
+++ b/sdk/examples/list_clusters.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"../ovirtsdk4"
+	"github.com/imjoey/go-ovirt"
 )
 
 func main() {

--- a/sdk/examples/list_datacenters.go
+++ b/sdk/examples/list_datacenters.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"../ovirtsdk4"
+	"github.com/imjoey/go-ovirt"
 )
 
 func main() {

--- a/sdk/examples/list_vms.go
+++ b/sdk/examples/list_vms.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"../ovirtsdk4"
+	"github.com/imjoey/go-ovirt"
 )
 
 func main() {


### PR DESCRIPTION
Using`github.com/imjoey/go-ovirt` to import the SDK itself formally in examples, not the directory `../ovirtsdk4`.