### PR TITLE
Add MustBuild() method in type builders, for convenience

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/go/TypesGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/TypesGenerator.java
@@ -282,6 +282,7 @@ public class TypesGenerator implements GoGenerator {
         buffer.addLine(  "builder.%1$s.SetHref(href)", typePrivateMemberName);
         buffer.addLine(  "return builder");
         buffer.addLine("}");
+        buffer.addLine();
         // Generate Build method
         buffer.addLine("func (builder *%1$s) Build() (*%2$s, error) {", goTypes.getBuilderName(type), typeClassName);
         buffer.addLine(  "if builder.err != nil {");
@@ -289,6 +290,16 @@ public class TypesGenerator implements GoGenerator {
         buffer.addLine(  "}");
         buffer.addLine(  "return builder.%1$s, nil", typePrivateMemberName);
         buffer.addLine("}");
+        buffer.addLine();
+        // Generate MustBuild method
+        buffer.addImport("fmt");
+        buffer.addLine("func (builder *%1$s) MustBuild() *%2$s {", goTypes.getBuilderName(type), typeClassName);
+        buffer.addLine(  "if builder.err != nil {");
+        buffer.addLine(    "panic(fmt.Sprintf(\"Failed to build %1$s instance, reason: %%v\", builder.err))", typeClassName);
+        buffer.addLine(  "}");
+        buffer.addLine(  "return builder.%1$s", typePrivateMemberName);
+        buffer.addLine("}");
+        buffer.addLine();
     }
 
     private void generateEnum(EnumType type) {


### PR DESCRIPTION
The type builders only have `Build()` method, which returns two values. The two returned values make callers inconvenience. The codes in example `add_tag.go` shows that.
```go
newTag, err := ovirtsdk4.NewTagBuilder().
	Name("mytag").
	Description("mytag desc").
	Build()
if err != nil {
	fmt.Printf("Construct a new tag failed, reason: %v\n", err)
}

resp, err := tagService.Add().Tag(newTag).Send()
```

This pr adds a method named `MustBuild` to return back just one `tag`. The codes with `MustBuild` should be more simple as blow.
```go
resp, err := tagService.Add().
	Tag(ovirtsdk4.NewTagBuilder().
		Name("mytag").
		Description("mytag desc").
		MustBuild()
	).
	Send()
```
