### PR TITLE
Fixes the error of attrs map not initialized.

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/go/WritersGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/WritersGenerator.java
@@ -188,6 +188,9 @@ public class WritersGenerator implements GoGenerator {
         Type memberType = member.getType();
         String tag = goNames.getTagStyleName(memberName);
         buffer.addLine("  if r, ok := object.%1$s(); ok {", goTypes.getMemberGetterMethodName(memberName));
+        buffer.addLine("    if attrs == nil {");
+        buffer.addLine("      attrs = make(map[string]string)");
+        buffer.addLine("    }");
         if (memberType instanceof PrimitiveType) {
             Model model = memberType.getModel();
             if (memberType == model.getBooleanType()) {


### PR DESCRIPTION
The variable `attrs` is not initialized in `XMLTypeWriteOne` functions of `writers.go`, which panics with message `panic: assignment to entry in nil map`.
This pr fixes it.