### PR TITLE
Implements the attached links processing by adding FollowLink() method in connection.go

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/go/ServicesGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/ServicesGenerator.java
@@ -663,7 +663,7 @@ public class ServicesGenerator implements GoGenerator {
             .collect(Collectors.toList());
         for (Parameter para : parameters) {
             generateResponseParameterGetterMethod(para, service);
-            generateResponseParameterMustGetterMethod(para, service);
+            // generateResponseParameterMustGetterMethod(para, service);
         }
     }
 

--- a/sdk/examples/add_affinity_label.go
+++ b/sdk/examples/add_affinity_label.go
@@ -51,6 +51,6 @@ func main() {
 		fmt.Printf("Failed to create a affinity label, reason: %v\n", err)
 		return
 	}
-	addedLabel := resp.MustLabel()
+	addedLabel, _ := resp.Label()
 	fmt.Printf("Affinity label with name (%v) added successfuly\n", addedLabel.MustName())
 }

--- a/sdk/examples/add_tag.go
+++ b/sdk/examples/add_tag.go
@@ -54,7 +54,7 @@ func main() {
 		fmt.Printf("Failed to create a tag, reason: %v\n", err)
 		return
 	}
-	tagAdded := resp.MustTag()
+	tagAdded, _ := resp.Tag()
 	fmt.Printf("Tag with name-(%v) and desc-(%v) added successfuly\n",
 		tagAdded.MustName(), tagAdded.MustDescription())
 

--- a/sdk/examples/assign_affinity_label_to_vm.go
+++ b/sdk/examples/assign_affinity_label_to_vm.go
@@ -61,7 +61,8 @@ func main() {
 	if err != nil {
 		fmt.Printf("Failed to get affinity label list, reason: %v\n", err)
 	}
-	for _, label := range resp.MustLabels().Slice() {
+	labels, _ := resp.Labels()
+	for _, label := range labels.Slice() {
 		if label.MustName() == "myaffinitylabel" {
 			affinityLabelID = label.MustId()
 			break

--- a/sdk/examples/assign_tag_to_vm.go
+++ b/sdk/examples/assign_tag_to_vm.go
@@ -70,7 +70,8 @@ func main() {
 	}
 
 	listResp, err := assignedTagsService.List().Send()
-	for _, tag := range listResp.MustTags().Slice() {
+	tags, _ := listResp.Tags()
+	for _, tag := range tags.Slice() {
 		fmt.Printf("Assigned tag name is %v\n", tag.MustName())
 	}
 }

--- a/sdk/examples/list_datacenters.go
+++ b/sdk/examples/list_datacenters.go
@@ -56,8 +56,8 @@ func main() {
 			if dcName, ok := dc.Name(); ok {
 				fmt.Printf(" name: %v", dcName)
 			}
-			if dcId, ok := dc.Id(); ok {
-				fmt.Printf(" id: %v", dcId)
+			if dcID, ok := dc.Id(); ok {
+				fmt.Printf(" id: %v", dcID)
 			}
 			fmt.Printf("  Supported versions are: ")
 			if svs, ok := dc.SupportedVersions(); ok {

--- a/sdk/examples/remove_tag.go
+++ b/sdk/examples/remove_tag.go
@@ -46,7 +46,8 @@ func main() {
 		fmt.Printf("Failed to get tag list, reason: %v\n", err)
 		return
 	}
-	for _, tag := range resp.MustTags().Slice() {
+	tags, _ := resp.Tags()
+	for _, tag := range tags.Slice() {
 		if tag.MustName() == "mytag" {
 			tagID = tag.MustId()
 			break


### PR DESCRIPTION
Fixes #73 . This pr has lots of changes, which includes:
1. Removes the `Must` version methods in type responses;
2. Finishes `FollowLink()` method in `connection.go` to retrieve type instances by processing the link hrefs.

The guide is shown in `examples/list_affinity_labels.go`, as blow
```go
// Print all affinity labels names and virtual machines
// which has assigned that affinity label
if vmSlice, ok := label.Vms(); ok {
	vms, err := conn.FollowLink(vmSlice)
	if err != nil {
		if href, ok := vmSlice.Href(); ok {
			fmt.Printf("Failed to follow vms link: %v, reason: %v\n", href, err)
			return
		}
	}
	if vms, ok := vms.(*ovirtsdk4.VmSlice); ok {
		for _, vmLink := range vms.Slice() {
			vm, err := conn.FollowLink(&vmLink)
			if err != nil {
				fmt.Printf("Failed to follow vm link: %v, reason: %v\n", vmLink.MustHref(), err)
				return
			}
			if vm, ok := vm.(*ovirtsdk4.Vm); ok {
				fmt.Printf("**** attached VM (%+v)\n", vm.MustName())
			}
		}
	}
}
```