### PR TITLE
Add Must version methods for request.Send/response.XXX

### DIFF
--- a/sdk/examples/list_vm_disks.go
+++ b/sdk/examples/list_vm_disks.go
@@ -41,15 +41,12 @@ func main() {
 	defer conn.Close()
 
 	vmsService := conn.SystemService().VmsService()
-
-	// Error not checked is not recommended
-	resp, _ := vmsService.List().Search("name=test4joey").Send()
-	vmSlice, _ := resp.Vms()
-	vmService := vmsService.VmService(vmSlice.Slice()[0].MustId())
+	// Use Must version methods to make a function call chain
+	vm := vmsService.List().Search("name=test4joey").MustSend().MustVms().Slice()[0]
+	vmService := vmsService.VmService(vm.MustId())
 	dasService := vmService.DiskAttachmentsService()
 
-	dasResp, _ := dasService.List().Send()
-	das, _ := dasResp.Attachments()
+	das := dasService.List().MustSend().MustAttachments()
 	for _, da := range das.Slice() {
 		disk, _ := conn.FollowLink(da.MustDisk())
 		if disk, ok := disk.(*ovirtsdk4.Disk); ok {

--- a/sdk/ovirtsdk4/connection.go
+++ b/sdk/ovirtsdk4/connection.go
@@ -114,8 +114,19 @@ func (c *Connection) FollowLink(object Href) (interface{}, error) {
 		requestCaller = serviceValue.MethodByName("Get").Call([]reflect.Value{})[0]
 	}
 	callerResponse := requestCaller.MethodByName("Send").Call([]reflect.Value{})[0]
-	// Method 0 could retrieve the data
-	returnedValues := callerResponse.Method(0).Call([]reflect.Value{})
+	// Get the method index, which is not the Must version
+	methodIndex := 0
+	callerResponseType := callerResponse.Type()
+	for i := 0; i < callerResponseType.NumMethod(); i++ {
+		if strings.HasPrefix(callerResponseType.Method(i).Name, "Must") {
+			methodIndex = i
+			break
+		}
+	}
+	methodIndex = 1 - methodIndex
+	// Retrieve the data
+	returnedValues := callerResponse.Method(methodIndex).Call([]reflect.Value{})
+
 	result, ok := returnedValues[0].Interface(), returnedValues[1].Bool()
 	if !ok {
 		return nil, errors.New("The data retrieved not exists")


### PR DESCRIPTION
The `Must` version methods are helper functions, which could make function invocation chains. If use `Must` methods, you should define `recover()` function in `defer` before calling them.