### PR TITLE
Support library version importing by using gokpg.in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ target/
 .project
 
 # Auto-generated files
-sdk/ovirtsdk4/services.go
-sdk/ovirtsdk4/types.go
-sdk/ovirtsdk4/readers.go
-sdk/ovirtsdk4/writers.go
+sdk/ovirtsdk/services.go
+sdk/ovirtsdk/types.go
+sdk/ovirtsdk/readers.go
+sdk/ovirtsdk/writers.go

--- a/.travis/deploy-codes.sh
+++ b/.travis/deploy-codes.sh
@@ -7,8 +7,8 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "master" ]; then
 fi
 
 # Pull current codes
-mkdir -p ./sdk/ovirtsdk4-git/
-cd ./sdk/ovirtsdk4-git/
+mkdir -p ./sdk/ovirtsdk-git/
+cd ./sdk/ovirtsdk-git/
 git init
 
 git config --global user.email "travis@travis-ci.org"
@@ -20,7 +20,7 @@ git pull origin master
 
 # Use newly generated codes to override the pulled ones
 rm -fr *.go README.md
-cp -r ../ovirtsdk4/* ./
+cp -r ../ovirtsdk/* ./
 
 # Copy examples/ and push into go-ovirt repository
 rm -fr ./examples

--- a/generator/src/main/java/org/ovirt/sdk/go/GoBuffer.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/GoBuffer.java
@@ -162,7 +162,7 @@ public class GoBuffer {
         buffer.append("");
 
         // Package:
-        buffer.append("package ovirtsdk4");
+        buffer.append("package ovirtsdk");
         buffer.append("\n");
 
         // Add the imports:

--- a/generator/src/main/java/org/ovirt/sdk/go/GoNames.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/GoNames.java
@@ -63,7 +63,7 @@ public class GoNames {
     private Set<String> reservedWords;
 
     // The name of the root package:
-    private String rootPackageName = "ovirtsdk4";
+    private String rootPackageName = "ovirtsdk";
 
     // The version number:
     private String version;

--- a/sdk/examples/add_affinity_label.go
+++ b/sdk/examples/add_affinity_label.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_bond.go
+++ b/sdk/examples/add_bond.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_datacenter.go
+++ b/sdk/examples/add_datacenter.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_floating_disk.go
+++ b/sdk/examples/add_floating_disk.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_group.go
+++ b/sdk/examples/add_group.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_host.go
+++ b/sdk/examples/add_host.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_independent_vm.go
+++ b/sdk/examples/add_independent_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_instance_type.go
+++ b/sdk/examples/add_instance_type.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_logical_network.go
+++ b/sdk/examples/add_logical_network.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_lun_disk_to_vm.go
+++ b/sdk/examples/add_lun_disk_to_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_mac_pool.go
+++ b/sdk/examples/add_mac_pool.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_nfs_data_storage_domain.go
+++ b/sdk/examples/add_nfs_data_storage_domain.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_nfs_iso_storage_domain.go
+++ b/sdk/examples/add_nfs_iso_storage_domain.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_tag.go
+++ b/sdk/examples/add_tag.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_template.go
+++ b/sdk/examples/add_template.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_user_public_sshkey.go
+++ b/sdk/examples/add_user_public_sshkey.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_vm.go
+++ b/sdk/examples/add_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_vm_disk.go
+++ b/sdk/examples/add_vm_disk.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_vm_from_template.go
+++ b/sdk/examples/add_vm_from_template.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_vm_nic.go
+++ b/sdk/examples/add_vm_nic.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_vm_snapshot.go
+++ b/sdk/examples/add_vm_snapshot.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_vm_with_sysprep.go
+++ b/sdk/examples/add_vm_with_sysprep.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/add_vnc_console.go
+++ b/sdk/examples/add_vnc_console.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/assign_affinity_label_to_vm.go
+++ b/sdk/examples/assign_affinity_label_to_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/assign_network_to_cluster.go
+++ b/sdk/examples/assign_network_to_cluster.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/assign_tag_to_vm.go
+++ b/sdk/examples/assign_tag_to_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/attach_nfs_data_storage_domain.go
+++ b/sdk/examples/attach_nfs_data_storage_domain.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/attach_nfs_iso_storage_domain.go
+++ b/sdk/examples/attach_nfs_iso_storage_domain.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/change_vm_cd.go
+++ b/sdk/examples/change_vm_cd.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/clone_vm_from_snapshot.go
+++ b/sdk/examples/clone_vm_from_snapshot.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/enable_serial_console.go
+++ b/sdk/examples/enable_serial_console.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/export_vm.go
+++ b/sdk/examples/export_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/follow_vm_links.go
+++ b/sdk/examples/follow_vm_links.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/import_glance_image.go
+++ b/sdk/examples/import_glance_image.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/import_vm.go
+++ b/sdk/examples/import_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/list_affinity_labels.go
+++ b/sdk/examples/list_affinity_labels.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/list_clusters.go
+++ b/sdk/examples/list_clusters.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/list_datacenters.go
+++ b/sdk/examples/list_datacenters.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/list_glance_images.go
+++ b/sdk/examples/list_glance_images.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/list_hosts_statistics.go
+++ b/sdk/examples/list_hosts_statistics.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/list_roles.go
+++ b/sdk/examples/list_roles.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/list_vm_disks.go
+++ b/sdk/examples/list_vm_disks.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/list_vm_snapshots.go
+++ b/sdk/examples/list_vm_snapshots.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/list_vm_tags.go
+++ b/sdk/examples/list_vm_tags.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/list_vms.go
+++ b/sdk/examples/list_vms.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/pin_vm.go
+++ b/sdk/examples/pin_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/register_vm.go
+++ b/sdk/examples/register_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/remove_host.go
+++ b/sdk/examples/remove_host.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/remove_tag.go
+++ b/sdk/examples/remove_tag.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/remove_vm.go
+++ b/sdk/examples/remove_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/search_vms.go
+++ b/sdk/examples/search_vms.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/set_vm_lease_storage_domain.go
+++ b/sdk/examples/set_vm_lease_storage_domain.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/start_vm.go
+++ b/sdk/examples/start_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/start_vm_with_cloudinit.go
+++ b/sdk/examples/start_vm_with_cloudinit.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/stop_vm.go
+++ b/sdk/examples/stop_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/unassign_tag_to_vm.go
+++ b/sdk/examples/unassign_tag_to_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/update_datacenter.go
+++ b/sdk/examples/update_datacenter.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/update_fencing_options.go
+++ b/sdk/examples/update_fencing_options.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/examples/update_quota_limits.go
+++ b/sdk/examples/update_quota_limits.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imjoey/go-ovirt"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func main() {

--- a/sdk/ovirtsdk/README.md
+++ b/sdk/ovirtsdk/README.md
@@ -9,13 +9,15 @@ oVirt Engine API.
 
 ## Usage
 
-To use the SDK you should import ovirtsdk4 package as follows:
+To use the SDK you should import ovirtsdk package as follows:
 
 ```go
 import (
-    "github.com/imjoey/go-ovirt"
+    ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4" // v4 <-> ovirt 4.x
 )
 ```
+
+> In product envrionment, you should __NEVER__ use `import "github.com/imjoey/go-ovirt"` that it imports the master branch which will always be under heavy development.
 
 That will give you access to all the classes of the SDK, and in particular
 to the `Connection` class. This is the entry point of the SDK,
@@ -26,7 +28,7 @@ and gives you access to the root of the tree of services of the API:
 import (
     "fmt"
     "time"
-    "github.com/imjoey/go-ovirt"
+    ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 inputRawURL := "https://10.1.111.229/ovirt-engine/api"

--- a/sdk/ovirtsdk/connection.go
+++ b/sdk/ovirtsdk/connection.go
@@ -17,7 +17,7 @@
 // Some codes of this file is from https://github.com/CpuID/ovirt-engine-sdk-go/blob/master/sdk/http/http.go.
 // And I made some bug fixes, Thanks to @CpuID
 
-package ovirtsdk4
+package ovirtsdk
 
 import (
 	"crypto/tls"

--- a/sdk/ovirtsdk/http.go
+++ b/sdk/ovirtsdk/http.go
@@ -13,7 +13,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-package ovirtsdk4
 
-// The version of the SDK:
-var SDK_VERSION = "4.2.0.a2"
+package ovirtsdk

--- a/sdk/ovirtsdk/reader.go
+++ b/sdk/ovirtsdk/reader.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package ovirtsdk4
+package ovirtsdk
 
 import (
 	"bytes"

--- a/sdk/ovirtsdk/reader_test.go
+++ b/sdk/ovirtsdk/reader_test.go
@@ -14,37 +14,26 @@
 // limitations under the License.
 //
 
-package ovirtsdk4
+package ovirtsdk
 
-type Href interface {
-	Href() (string, bool)
-}
+import (
+	"testing"
 
-// Link represents struct of href and rel attributes
-type Link struct {
-	href *string
-	rel  *string
-}
+	"github.com/stretchr/testify/assert"
+)
 
-// Struct represents the base for all struts defined in types.go
-type Struct struct {
-	href *string
-}
+func TestReadStrings(t *testing.T) {
+	assert := assert.New(t)
+	xmlstring := `
+    <cpu>
+        <type>x86_64</type>
+        <type>Intel SandyBridge Family</type>
+    </cpu>
+	`
+	reader := NewXMLReader([]byte(xmlstring))
 
-func (p *Struct) Href() (string, bool) {
-	if p.href != nil {
-		return *p.href, true
-	}
-	return "", false
-}
+	strs, err := reader.ReadStrings(nil)
+	assert.Nil(err)
 
-func (p *Struct) MustHref() string {
-	if p.href == nil {
-		panic("href attribute must exist")
-	}
-	return *p.href
-}
-
-func (p *Struct) SetHref(attr string) {
-	p.href = &attr
+	assert.Equal([]string{"x86_64", "Intel SandyBridge Family"}, strs)
 }

--- a/sdk/ovirtsdk/readers_test.go
+++ b/sdk/ovirtsdk/readers_test.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package ovirtsdk4
+package ovirtsdk
 
 import (
 	"testing"

--- a/sdk/ovirtsdk/service.go
+++ b/sdk/ovirtsdk/service.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package ovirtsdk4
+package ovirtsdk
 
 import (
 	"bytes"

--- a/sdk/ovirtsdk/type.go
+++ b/sdk/ovirtsdk/type.go
@@ -14,26 +14,37 @@
 // limitations under the License.
 //
 
-package ovirtsdk4
+package ovirtsdk
 
-import (
-	"testing"
+type Href interface {
+	Href() (string, bool)
+}
 
-	"github.com/stretchr/testify/assert"
-)
+// Link represents struct of href and rel attributes
+type Link struct {
+	href *string
+	rel  *string
+}
 
-func TestReadStrings(t *testing.T) {
-	assert := assert.New(t)
-	xmlstring := `
-    <cpu>
-        <type>x86_64</type>
-        <type>Intel SandyBridge Family</type>
-    </cpu>
-	`
-	reader := NewXMLReader([]byte(xmlstring))
+// Struct represents the base for all struts defined in types.go
+type Struct struct {
+	href *string
+}
 
-	strs, err := reader.ReadStrings(nil)
-	assert.Nil(err)
+func (p *Struct) Href() (string, bool) {
+	if p.href != nil {
+		return *p.href, true
+	}
+	return "", false
+}
 
-	assert.Equal([]string{"x86_64", "Intel SandyBridge Family"}, strs)
+func (p *Struct) MustHref() string {
+	if p.href == nil {
+		panic("href attribute must exist")
+	}
+	return *p.href
+}
+
+func (p *Struct) SetHref(attr string) {
+	p.href = &attr
 }

--- a/sdk/ovirtsdk/utils.go
+++ b/sdk/ovirtsdk/utils.go
@@ -14,25 +14,27 @@
 // limitations under the License.
 //
 
-package ovirtsdk4
+package ovirtsdk
 
 import (
-	"bytes"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
+	"reflect"
 )
 
-func TestCpuWriteOne(t *testing.T) {
-	assert := assert.New(t)
-	var b bytes.Buffer
-	writer := NewXMLWriter(&b)
-	cpu, err := NewCpuBuilder().Type("Intel SandyBridge Family").Architecture(ARCHITECTURE_X86_64).Build()
-	assert.Nil(err)
-	err = XMLCpuWriteOne(writer, cpu, "")
-	assert.Nil(err)
-	writer.Flush()
-	assert.Equal("<cpu><architecture>x86_64</architecture><type>Intel SandyBridge Family</type></cpu>",
-		string(b.Bytes()))
+// Contains returns if target contains the obj parameter
+func Contains(obj interface{}, target interface{}) bool {
+	targetValue := reflect.ValueOf(target)
+	switch reflect.TypeOf(target).Kind() {
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < targetValue.Len(); i++ {
+			if targetValue.Index(i).Interface() == obj {
+				return true
+			}
+		}
+	case reflect.Map:
+		if targetValue.MapIndex(reflect.ValueOf(obj)).IsValid() {
+			return true
+		}
+	}
 
+	return false
 }

--- a/sdk/ovirtsdk/version.go
+++ b/sdk/ovirtsdk/version.go
@@ -13,28 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+package ovirtsdk
 
-package ovirtsdk4
-
-import (
-	"reflect"
-)
-
-// Contains returns if target contains the obj parameter
-func Contains(obj interface{}, target interface{}) bool {
-	targetValue := reflect.ValueOf(target)
-	switch reflect.TypeOf(target).Kind() {
-	case reflect.Slice, reflect.Array:
-		for i := 0; i < targetValue.Len(); i++ {
-			if targetValue.Index(i).Interface() == obj {
-				return true
-			}
-		}
-	case reflect.Map:
-		if targetValue.MapIndex(reflect.ValueOf(obj)).IsValid() {
-			return true
-		}
-	}
-
-	return false
-}
+// The version of the SDK:
+var SDK_VERSION = "4.2.0.a2"

--- a/sdk/ovirtsdk/writer.go
+++ b/sdk/ovirtsdk/writer.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package ovirtsdk4
+package ovirtsdk
 
 import (
 	"bufio"

--- a/sdk/ovirtsdk/writers_test.go
+++ b/sdk/ovirtsdk/writers_test.go
@@ -14,4 +14,25 @@
 // limitations under the License.
 //
 
-package ovirtsdk4
+package ovirtsdk
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCpuWriteOne(t *testing.T) {
+	assert := assert.New(t)
+	var b bytes.Buffer
+	writer := NewXMLWriter(&b)
+	cpu, err := NewCpuBuilder().Type("Intel SandyBridge Family").Architecture(ARCHITECTURE_X86_64).Build()
+	assert.Nil(err)
+	err = XMLCpuWriteOne(writer, cpu, "")
+	assert.Nil(err)
+	writer.Flush()
+	assert.Equal("<cpu><architecture>x86_64</architecture><type>Intel SandyBridge Family</type></cpu>",
+		string(b.Bytes()))
+
+}

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -113,7 +113,7 @@ limitations under the License.
               <arguments>
                 <argument>build</argument>
                 <argument>-v</argument>
-                <argument>./ovirtsdk4</argument>
+                <argument>./ovirtsdk</argument>
               </arguments>
             </configuration>
           </execution>
@@ -131,7 +131,7 @@ limitations under the License.
               <arguments>
                 <argument>test</argument>
                 <argument>-v</argument>
-                <argument>./ovirtsdk4</argument>
+                <argument>./ovirtsdk</argument>
               </arguments>
             </configuration>
           </execution>


### PR DESCRIPTION
Use `gopkg.in/imjoey/go-ovirt.v4` as the import path. It will make library support multiple versions and easy to manage.

v4 means responding the ovirt-engine 4.x.