### PR TITLE
Refactor the overall project for better robustness and maintainability

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/go/GoBuffer.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/GoBuffer.java
@@ -81,7 +81,9 @@ public class GoBuffer {
      * Adds multiple imports.
      */
     public void addImports(List<String> imports) {
-        imports.forEach(this::addImport);
+        if (imports != null && imports.size() > 0) {
+            imports.forEach(this::addImport);
+        }
     }
 
     /**

--- a/generator/src/main/java/org/ovirt/sdk/go/GoFuncName.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/GoFuncName.java
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 Joey <majunjiev@gmail.com>.
+Copyright (c) 2018 Joey <majunjiev@gmail.com>.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ limitations under the License.
 package org.ovirt.sdk.go;
 
 /**
- * This class represents the fully qualified name of a Go class, composed by the package name and the struct.
+ * This class represents the fully qualified name of a Go function and its package
  */
-public class GoClassName {
+public class GoFuncName {
     private String packageName;
     private String simpleName;
 

--- a/generator/src/main/java/org/ovirt/sdk/go/GoPackages.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/GoPackages.java
@@ -1,0 +1,130 @@
+/*
+Copyright (c) 2018 Joey <majunjiev@gmail.com>.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package org.ovirt.sdk.go;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * This class contains the rules used to calculate the names of generated Go packages.
+ */
+@ApplicationScoped
+public class GoPackages {
+
+    // The relative names of the packages:
+    public static final String READERS_PACKAGE = "readers";
+    public static final String SERVICES_PACKAGE = "services";
+    public static final String TYPES_PACKAGE = "types";
+    public static final String WRITERS_PACKAGE = "writers";
+    public static final String VERSION_PACKAGE = "version";
+
+    // The name of the root package:
+    private String rootPackageName = "ovirtsdk";
+
+    // The version number:
+    private String version;
+
+    // root package url prefix
+    private String rootPackageUrlPrefix = "github.com/imjoey/sdk";
+
+    public void setRootPackageUrlPrefix(String newRootPackageUrlPrefix) {
+        rootPackageUrlPrefix = newRootPackageUrlPrefix;
+    }
+
+    public String getRootPackageUrlPrefix() {
+        return rootPackageUrlPrefix;
+    }
+
+    /**
+     * Sets the version.
+     */
+    public void setVersion(String newVersion) {
+        version = newVersion;
+    }
+
+    /**
+     * Get the version.
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Get the name of the root package.
+     */
+    public String getRootPackageName() {
+        return rootPackageName;
+    }
+
+    /**
+     * Get the name of the types package.
+     */
+    public String getTypesPackageName() {
+        return getPackageName(TYPES_PACKAGE);
+    }
+
+    /**
+     * Get the name of the models builder package.
+     *  - just use type package name.
+     */
+    public String getTypeBuildersPackageName() {
+        return getTypesPackageName();
+    }
+
+    /**
+     * Get the name of the readers package.
+     */
+    public String getReadersPackageName() {
+        return getPackageName(READERS_PACKAGE);
+    }
+
+    /**
+     * Get the name of the writers package.
+     */
+    public String getWritersPackageName() {
+        return getPackageName(WRITERS_PACKAGE);
+    }
+
+    /**
+     * Get the name of the services package.
+     */
+    public String getServicesPackageName() {
+        return getPackageName(SERVICES_PACKAGE);
+    }
+
+    /**
+     * Get the name of the version package
+     */
+    public String getVersionPackageName() {
+        return getPackageName(VERSION_PACKAGE);
+    }
+
+    /**
+     * Get the complete name of the given package.
+     */
+    public String getPackageName(String... relativeNames) {
+        StringBuilder buffer = new StringBuilder();
+        buffer.append(rootPackageName);
+        if (relativeNames != null && relativeNames.length > 0) {
+            for (String relativeName : relativeNames) {
+                buffer.append('/');
+                buffer.append(relativeName);
+            }
+        }
+        return buffer.toString();
+    }
+
+}

--- a/generator/src/main/java/org/ovirt/sdk/go/GoReservedWords.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/GoReservedWords.java
@@ -26,7 +26,7 @@ import javax.inject.Singleton;
 import org.ovirt.api.metamodel.tool.ReservedWords;
 
 /**
- * This class is a producer of the set of Python reserved words.
+ * This class is a producer of the set of Go reserved words.
  */
 @Singleton
 public class GoReservedWords {
@@ -37,9 +37,6 @@ public class GoReservedWords {
         // Create the set:
         words = new HashSet<>();
 
-        // type用于声明自定义类型
-        // map用于声明map类型数据
-        // range用于读取slice、map、channel数据
         // definition
         words.add("var");
         words.add("const");

--- a/generator/src/main/java/org/ovirt/sdk/go/GoTypeReference.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/GoTypeReference.java
@@ -48,7 +48,9 @@ public class GoTypeReference {
     }
 
     public void addImport(String newImport) {
-        imports.add(newImport);
+        if (newImport != null && newImport.length() >0 ) {
+            imports.add(newImport);
+        }
     }
 
     @Override

--- a/generator/src/main/java/org/ovirt/sdk/go/GoTypes.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/GoTypes.java
@@ -16,97 +16,278 @@ limitations under the License.
 
 package org.ovirt.sdk.go;
 
-import static java.util.stream.Collectors.joining;
+import java.util.List;
 
 import javax.inject.Inject;
 
+import org.ovirt.api.metamodel.concepts.EnumType;
+import org.ovirt.api.metamodel.concepts.ListType;
+import org.ovirt.api.metamodel.concepts.Model;
 import org.ovirt.api.metamodel.concepts.Name;
+import org.ovirt.api.metamodel.concepts.NameParser;
 import org.ovirt.api.metamodel.concepts.PrimitiveType;
+import org.ovirt.api.metamodel.concepts.Service;
+import org.ovirt.api.metamodel.concepts.StructType;
 import org.ovirt.api.metamodel.concepts.Type;
-import org.ovirt.api.metamodel.tool.Words;
 
 /**
- * For in type in Go
+ * This class calculates the type references for the Go structs and the Go funcs generated from the model.
  */
 public class GoTypes {
 
-    @Inject private GoNames goNames;
+    // Suffixes to add to the different types of classes generated for each type:
+    private static final Name SLICE_NAME = NameParser.parseUsingCase("Slice");
+    private static final Name BUILDER_NAME = NameParser.parseUsingCase("Builder");
+    private static final Name READER_NAME = NameParser.parseUsingCase("Reader");
+    private static final Name WRITER_NAME = NameParser.parseUsingCase("Writer");
+    private static final Name SERVICE_NAME = NameParser.parseUsingCase("Service");
+    
+    // Suffixes to add to the different functions for each type
+    private static final Name READ_ONE_SUFFIX = NameParser.parseUsingCase("ReadOne");
+    private static final Name READ_MANY_SUFFIX = NameParser.parseUsingCase("ReadMany");
+    private static final Name WRITE_ONE_SUFFIX = NameParser.parseUsingCase("WriteOne");
+    private static final Name WRITE_MANY_SUFFIX = NameParser.parseUsingCase("WriteMany");
+    private static final Name BUILDER_SUFFIX = NameParser.parseUsingCase("Builder");
+    private static final Name PRESENT_SUFFIX = NameParser.parseUsingCase("Present");
+
+    // Prefixes for the XML and JSON readers and writers:
+    private static final Name XML_PREFIX = NameParser.parseUsingCase("XML");
+    // Prefixes for functions
+    private static final Name NEW_PREFIX = NameParser.parseUsingCase("New");
+    private static final Name SET_PREFIX = NameParser.parseUsingCase("Set");
+    private static final Name MUST_PREFIX = NameParser.parseUsingCase("Must");
+
 
     // Reference to the object used to do computations with words.
-    @Inject
-    private Words words;
+    @Inject private GoNames goNames;
+    @Inject private GoPackages goPackages;
+
+    /**
+     * Calculates the Go name that corresponds to the given type.
+     */
+    public GoClassName getTypeName(Type type) {
+        return getClassName(type, goPackages.getTypesPackageName(), null, null, true);
+    }
+
+    public GoClassName getTypeSliceName(Type type) {
+        return getClassName(type, goPackages.getTypesPackageName(), null, SLICE_NAME, true);
+    }
 
     /**
      * Calculates the name of the builder class that should be generated for the given type. For example,
      * for the {@code Vm} type it will generate {@code org.ovirt.engine.model} as the package name and
-     * {@code V4VmBuilder} as the simple class name.
+     * {@code VmBuilder} as the simple class name.
      */
-    public String getBuilderName(Type type) {
-        String typeName = goNames.getTypeName(type).getClassName();
-        String result = String.join("", typeName, "Builder");
-        return goNames.renameReserved(result);
+    public GoClassName getBuilderName(Type type) {
+        return getClassName(type, goPackages.getTypeBuildersPackageName(), null, BUILDER_NAME, true);
     }
 
-    public String getStructSliceTypeName(Type type) {
-        String typename = goNames.getTypeName(type).getClassName();
-        String result = String.join("", typename, "Slice");
-        return goNames.renameReserved(result);
+    /**
+     * Calculates the Go name of the xml-reader for the given type.
+     */
+    public GoClassName getXMLReaderName(Type type) {
+        return getClassName(type, goPackages.getReadersPackageName(), XML_PREFIX, READER_NAME, true);
     }
 
-    public String getNewBuilderFuncName(Type type) {
-        GoClassName typeName = goNames.getTypeName(type);
-        String result = String.join("", "New", typeName.getClassName(), "Builder");
-        return result;
+    /**
+     * Calculates the Go name of the xml-writer for the given type.
+     */
+    public GoClassName getXMLWriterName(Type type) {
+        return getClassName(type, goPackages.getWritersPackageName(), XML_PREFIX, WRITER_NAME, true);
     }
 
-    public String getServiceConstructorFuncName(GoClassName serviceName) {
-        String serviceClassName = serviceName.getClassName();
-        serviceClassName = serviceClassName.substring(0, 1).toUpperCase() + serviceClassName.substring(1);
-        String result = String.join("", "New", serviceClassName);
-        return result;
+    public GoFuncName getNewBuilderFuncName(Type type) {
+        GoFuncName funcName = new GoFuncName();
+        Name newName = decorateName(type.getName(), NEW_PREFIX, BUILDER_SUFFIX);
+        funcName.setSimpleName(goNames.getExportableFuncStyleName(newName));
+        return funcName;
     }
 
-    public String getXmlReadOneFuncName(Type type) {
-        GoClassName typeName = goNames.getTypeName(type);
-        String result = String.join("", "XML", typeName.getClassName(), "ReadOne");
-        return goNames.renameReserved(result);
+    public GoFuncName getNewServiceFuncName(Service service) {
+        GoFuncName funcName = new GoFuncName();
+        Name newName = decorateName(service.getName(), NEW_PREFIX, SERVICE_NAME);
+        funcName.setSimpleName(goNames.getExportableFuncStyleName(newName));
+        return funcName;
     }
 
-    public String getXmlReadManyFuncName(Type type) {
-        GoClassName typeName = goNames.getTypeName(type);
-        String result = String.join("", "XML", typeName.getClassName(), "ReadMany");
-        return goNames.renameReserved(result);
+    public GoFuncName getXmlReadOneFuncName(Type type) {
+        GoFuncName funcName = new GoFuncName();
+        Name newName = decorateName(type.getName(), XML_PREFIX, READ_ONE_SUFFIX);
+        funcName.setSimpleName(goNames.getExportableFuncStyleName(newName));
+        return funcName;
     }
 
-    public String getXmlWriteOneFuncName(Type type) {
-        GoClassName typeName = goNames.getTypeName(type);
-        String result = String.join("", "XML", typeName.getClassName(), "WriteOne");
-        return goNames.renameReserved(result);
+    public GoFuncName getXmlReadManyFuncName(Type type) {
+        GoFuncName funcName = new GoFuncName();
+        Name newName = decorateName(type.getName(), XML_PREFIX, READ_MANY_SUFFIX);
+        funcName.setSimpleName(goNames.getExportableFuncStyleName(newName));
+        return funcName;
     }
 
-    public String getXmlWriteManyFuncName(Type type) {
-        GoClassName typeName = goNames.getTypeName(type);
-        String result = String.join("", "XML", typeName.getClassName(), "WriteMany");
-        return goNames.renameReserved(result);
+    public GoFuncName getXmlWriteOneFuncName(Type type) {
+        GoFuncName funcName = new GoFuncName();
+        Name newName = decorateName(type.getName(), XML_PREFIX, WRITE_ONE_SUFFIX);
+        funcName.setSimpleName(goNames.getExportableFuncStyleName(newName));
+        return funcName;
     }
 
-    public String getMemberSetterMethodName(Name name) {
-        String result = name.words().map(words::capitalize).collect(joining());
-        return goNames.renameReserved("Set" + result);
+    public GoFuncName getXmlWriteManyFuncName(Type type) {
+        GoFuncName funcName = new GoFuncName();
+        Name newName = decorateName(type.getName(), XML_PREFIX, WRITE_MANY_SUFFIX);
+        funcName.setSimpleName(goNames.getExportableFuncStyleName(newName));
+        return funcName;
     }
 
-    public String getMemberGetterMethodName(Name name) {
-        String result = name.words().map(words::capitalize).collect(joining());
-        return goNames.renameReserved(result);
+    public GoFuncName getMemberSetterMethodName(Name name) {
+        GoFuncName funcName = new GoFuncName();
+        Name newName = decorateName(name, SET_PREFIX, null);
+        funcName.setSimpleName(goNames.getExportableFuncStyleName(newName));
+        return funcName;
     }
 
-    public String getMemberMustGetterMethodName(Name name) {
-        return "Must" + getMemberGetterMethodName(name);
+    public GoFuncName getMemberGetterMethodName(Name name) {
+        GoFuncName funcName = new GoFuncName();
+        funcName.setSimpleName(goNames.getExportableFuncStyleName(name));
+        return funcName;
     }
 
-    public String getMemberPresentMethodName(Name name) {
-        String result = name.words().map(words::capitalize).collect(joining());
-        return goNames.renameReserved(result + "Present");
+    public GoFuncName getMemberMustGetterMethodName(Name name) {
+        GoFuncName funcName = new GoFuncName();
+        Name newName = decorateName(name, MUST_PREFIX, null);
+        funcName.setSimpleName(goNames.getExportableFuncStyleName(newName));
+        return funcName;
+    }
+
+    public GoFuncName getMemberPresentMethodName(Name name) {
+        GoFuncName funcName = new GoFuncName();
+        Name newName = decorateName(name, null, PRESENT_SUFFIX);
+        funcName.setSimpleName(goNames.getExportableFuncStyleName(newName));
+        return funcName;
+    }
+
+    private GoClassName getClassName(Type type, String packageName, Name prefix, Name suffix, boolean exportable) {
+        if (type instanceof PrimitiveType) {
+            return getPrimitiveTypeName((PrimitiveType) type, false);
+        }
+        if (type instanceof StructType || type instanceof EnumType) {
+            Name name = decorateName(type.getName(), prefix, suffix);
+            GoClassName typeName = new GoClassName();
+            // typeName.setPackageName(packageName);
+            if (exportable) {
+                typeName.setSimpleName(goNames.getExportableClassStyleName(name));
+            } else {
+                typeName.setSimpleName(goNames.getUnexportableClassStyleName(name));
+            }
+            return typeName;
+        }
+        throw new RuntimeException("Don't know how to calculate the Java type name for type \"" + type + "\"");
+    }
+
+    private GoClassName getPrimitiveTypeName(PrimitiveType type, boolean pointer) {
+        GoClassName name = new GoClassName();
+        Model model = type.getModel();
+        if (type == model.getBooleanType()) {
+            name.setSimpleName(pointer ? "*bool" : "bool");
+        }
+        else if (type == model.getIntegerType()) {
+            name.setSimpleName(pointer ? "*int64" : "int64");
+        }
+        else if (type == model.getDecimalType()) {
+            name.setSimpleName(pointer ? "*float64" : "float64");
+        }
+        else if (type == model.getStringType()) {
+            name.setSimpleName(pointer ? "*string" : "string");
+        }
+        else if (type == model.getDateType()) {
+            name.setPackageName("time");
+            name.setSimpleName(pointer ? "*time.Time" : "time.Time");
+        }
+        else {
+            throw new RuntimeException("Don't know how to calculate the Java type reference for type \"" + type + "\"");
+        }
+        return name;
+    }
+
+    private GoTypeReference getTypeReference(Type type, boolean pointer) {
+        if (type instanceof PrimitiveType) {
+            GoClassName name = getPrimitiveTypeName((PrimitiveType) type, pointer);
+            GoTypeReference reference = new GoTypeReference();
+            reference.addImport(name.getPackageName());
+            reference.setText(name.getSimpleName());
+            return reference;
+        }
+        if (type instanceof StructType) {
+            return getStructReference((StructType) type, pointer);
+        }
+        if (type instanceof EnumType) {
+            return getEnumReference((EnumType) type, pointer);
+        }
+        if (type instanceof ListType) {
+            return getListReference((ListType) type, pointer);
+        }
+        throw new RuntimeException("Don't know how to calculate the Java type reference for type \"" + type + "\"");
+    }
+
+    public GoTypeReference getTypeReferenceAsParameter(Type type) {
+        GoTypeReference reference = getTypeReference(type, false);
+        if (type instanceof StructType) {
+            reference.setText(goNames.withPointer(reference.getText()));
+        }
+        return reference;
+    }
+
+    public GoTypeReference getTypeReferenceAsAttribute(Type type) {
+        return getTypeReference(type, true);
+    }
+
+    public GoTypeReference getTypeReferenceAsVaraible(Type type) {
+        if (type instanceof StructType) {
+            return getTypeReference(type, true);
+        }
+        return getTypeReference(type, false);
+    }
+
+    public GoTypeReference getTypeReferenceAsReturnvalue(Type type) {
+        if (type instanceof StructType) {
+            return getTypeReference(type, true);
+        }
+        return getTypeReference(type, false);
+    }
+
+    private GoTypeReference getStructReference(StructType type, boolean pointer) {
+        GoTypeReference reference = new GoTypeReference();
+        String text = goNames.getExportableClassStyleName(type.getName());
+        if (pointer) {
+            text = goNames.withPointer(text);
+        }
+        reference.setText(text);
+        return reference;
+    }
+
+    private GoTypeReference getEnumReference(EnumType type, boolean pointer) {
+        GoTypeReference reference = new GoTypeReference();
+        String text = goNames.getExportableClassStyleName(type.getName());
+        if (pointer) {
+            text = goNames.withPointer(text);
+        }
+        reference.setText(text);
+        return reference;
+    }
+
+    private GoTypeReference getListReference(ListType type, boolean pointer) {
+        GoTypeReference reference = new GoTypeReference();
+        Type elementType = type.getElementType();
+        if (elementType instanceof StructType) {
+            GoClassName typeSlice = getTypeSliceName(elementType);
+            reference.addImport(typeSlice.getPackageName());
+            reference.setText(goNames.withPointer(typeSlice.getSimpleName()));
+        } else {
+            GoTypeReference elementTypeReference = getTypeReference(elementType, false);
+            // use Recursion to return []EnumType / []string
+            reference.setImports(elementTypeReference.getImports());
+            reference.setText("[]" + elementTypeReference.getText());
+        }
+        return reference;
     }
 
     public Boolean isGoPrimitiveType(Type type) {
@@ -120,6 +301,20 @@ public class GoTypes {
                 }
         }
         return false;
+    }
+
+    /**
+     * Decorates a name with optional prefix and suffix.
+     */
+    private Name decorateName(Name name, Name prefix, Name suffix) {
+        List<String> words = name.getWords();
+        if (prefix != null) {
+            words.addAll(0, prefix.getWords());
+        }
+        if (suffix != null) {
+            words.addAll(suffix.getWords());
+        }
+        return new Name(words);
     }
 
 }

--- a/generator/src/main/java/org/ovirt/sdk/go/Tool.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/Tool.java
@@ -42,7 +42,7 @@ public class Tool {
     private static final String VERSION_OPTION = "version";
 
     // Reference to the objects used to calculate Python names:
-    @Inject private GoNames goNames;
+    @Inject private GoPackages goPackages;
 
     // References to the generators:
     @Inject @Any
@@ -122,7 +122,7 @@ public class Tool {
         builtinTypes.addBuiltinTypes(model);
 
         // Configure the object used to generate names:
-        goNames.setVersion(version);
+        goPackages.setVersion(version);
 
         // Run the generators:
         if (outDir != null) {

--- a/generator/src/main/java/org/ovirt/sdk/go/VersionGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/VersionGenerator.java
@@ -30,7 +30,7 @@ public class VersionGenerator implements GoGenerator {
     private File out;
 
     // Reference to the objects used to generate the code:
-    @Inject private GoNames goNames;
+    @Inject private GoPackages goPackages;
 
     // The buffer used to generate the Ruby code:
     private GoBuffer buffer;
@@ -42,7 +42,7 @@ public class VersionGenerator implements GoGenerator {
     public void generate(Model model) throws IOException {
         // Prepare the buffer:
         buffer = new GoBuffer();
-        buffer.setPackageName(goNames.getVersionPackageName());
+        buffer.setPackageName(goPackages.getVersionPackageName());
 
         // Generate the source:
         generateVersion();
@@ -58,7 +58,7 @@ public class VersionGenerator implements GoGenerator {
 
     public void generateVersion() {
         // Generate the version constant:
-        String version = goNames.getVersion();
+        String version = goPackages.getVersion();
         buffer.addLine("// The version of the SDK:");
         buffer.addLine("var SDK_VERSION = \"%1$s\"", version.toLowerCase());
         buffer.addLine();

--- a/sdk/examples/add_affinity_label.go
+++ b/sdk/examples/add_affinity_label.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addAffinityLabel() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/add_bond.go
+++ b/sdk/examples/add_bond.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addBond() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -63,26 +63,26 @@ func main() {
 	hostService := hostsService.HostService(host.MustId())
 
 	// Configure the host adding a bond with two slaves, and attaching it to a network with an static IP address
-	setupNetworkResp, err := hostService.SetupNetworks().
+	_, err = hostService.SetupNetworks().
 		ModifiedBondsOfAny(
 			ovirtsdk4.NewHostNicBuilder().
 				Name("bond0").
 				Bonding(
 					ovirtsdk4.NewBondingBuilder().
 						OptionsOfAny(
-							*ovirtsdk4.NewOptionBuilder().
+							ovirtsdk4.NewOptionBuilder().
 								Name("mode").
 								Value("1").
 								MustBuild(),
-							*ovirtsdk4.NewOptionBuilder().
+							ovirtsdk4.NewOptionBuilder().
 								Name("miimon").
 								Value("100").
 								MustBuild()).
 						SlavesOfAny(
-							*ovirtsdk4.NewHostNicBuilder().
+							ovirtsdk4.NewHostNicBuilder().
 								Name("eth0").
 								MustBuild(),
-							*ovirtsdk4.NewHostNicBuilder().
+							ovirtsdk4.NewHostNicBuilder().
 								Name("eth1").
 								MustBuild()).
 						MustBuild()).
@@ -94,7 +94,7 @@ func main() {
 						Name("mynetwork").
 						MustBuild()).
 				IpAddressAssignmentsOfAny(
-					*ovirtsdk4.NewIpAddressAssignmentBuilder().
+					ovirtsdk4.NewIpAddressAssignmentBuilder().
 						AssignmentMethod(
 							ovirtsdk4.BOOTPROTOCOL_STATIC).
 						Ip(

--- a/sdk/examples/add_datacenter.go
+++ b/sdk/examples/add_datacenter.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addDatacenter() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/add_floating_disk.go
+++ b/sdk/examples/add_floating_disk.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addFloatingDisk() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/add_group.go
+++ b/sdk/examples/add_group.go
@@ -52,7 +52,7 @@ func main() {
 
 	// Use the "add" method to add group from a directory service. Please note that domain name is name of the
 	// authorization provider
-	addgResp, err := groupsService.Add().
+	_, err = groupsService.Add().
 		Group(
 			ovirtsdk4.NewGroupBuilder().
 				Name("Developers").

--- a/sdk/examples/add_host.go
+++ b/sdk/examples/add_host.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addHost() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -69,7 +69,7 @@ func main() {
 		return
 	}
 	if host, ok := addHostResp.Host(); ok {
-		hostService := hostsService.HostService(host.MustId)
+		hostService := hostsService.HostService(host.MustId())
 		// Wait till the host is up
 		for {
 			time.Sleep(5 * time.Second)

--- a/sdk/examples/add_independent_vm.go
+++ b/sdk/examples/add_independent_vm.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addIndependentVM() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/add_instance_type.go
+++ b/sdk/examples/add_instance_type.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addInstanceType() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/add_logical_network.go
+++ b/sdk/examples/add_logical_network.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addLogicalNetwork() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/add_lun_disk_to_vm.go
+++ b/sdk/examples/add_lun_disk_to_vm.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addLunDiskToVM() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -67,7 +67,7 @@ func main() {
 							ovirtsdk4.NewHostStorageBuilder().
 								Type(ovirtsdk4.STORAGETYPE_ISCSI).
 								LogicalUnitsOfAny(
-									*ovirtsdk4.NewLogicalUnitBuilder().
+									ovirtsdk4.NewLogicalUnitBuilder().
 										Address("192.168.200.3").
 										Port(3260).
 										Target("iqn.2014-07.org.ovirt:storage").

--- a/sdk/examples/add_mac_pool.go
+++ b/sdk/examples/add_mac_pool.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addMacPool() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -56,7 +56,7 @@ func main() {
 			ovirtsdk4.NewMacPoolBuilder().
 				Name("mymacpool").
 				RangesOfAny(
-					*ovirtsdk4.NewRangeBuilder().
+					ovirtsdk4.NewRangeBuilder().
 						From("02:00:00:00:00:00").
 						To("02:00:00:01:00:00").
 						MustBuild()).

--- a/sdk/examples/add_nfs_data_storage_domain.go
+++ b/sdk/examples/add_nfs_data_storage_domain.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addNFSDataStorageDomain() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/add_nfs_iso_storage_domain.go
+++ b/sdk/examples/add_nfs_iso_storage_domain.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addISODataStorageDomain() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/add_tag.go
+++ b/sdk/examples/add_tag.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addTag() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/add_template.go
+++ b/sdk/examples/add_template.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addTemplate() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -59,8 +59,8 @@ func main() {
 	// Get the identifiers of the disks attached to the virtual machine. We # need this because we want to tell the
 	// server to create the disks of the template using a format different to the format used by the original disks	.
 	var diskIDs []string
-	das, _ := conn.FollowLink(vm.MustDiskAttachments())
-	if das, ok := disks.(*ovirtsdk4.DiskAttachmentSlice); ok {
+	dasInterface, _ := conn.FollowLink(vm.MustDiskAttachments())
+	if das, ok := dasInterface.(*ovirtsdk4.DiskAttachmentSlice); ok {
 		for _, da := range das.Slice() {
 			diskIDs = append(diskIDs, da.MustDisk().MustId())
 		}

--- a/sdk/examples/add_user_public_sshkey.go
+++ b/sdk/examples/add_user_public_sshkey.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addUserPublicSSHKey() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/add_vm.go
+++ b/sdk/examples/add_vm.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addVM() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/add_vm_disk.go
+++ b/sdk/examples/add_vm_disk.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addVMDisk() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -73,7 +73,7 @@ func main() {
 						Format(ovirtsdk4.DISKFORMAT_COW).
 						ProvisionedSize(int64(10) * int64(1<<30)).
 						StorageDomainsOfAny(
-							*ovirtsdk4.NewStorageDomainBuilder().
+							ovirtsdk4.NewStorageDomainBuilder().
 								Name("mydata").
 								MustBuild()).
 						MustBuild()).

--- a/sdk/examples/add_vm_from_template.go
+++ b/sdk/examples/add_vm_from_template.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addVMFromTemplate() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -104,13 +104,13 @@ func main() {
 									MustBuild()).
 							// Use the vararg syntax to add just one or some
 							DiskAttachmentsOfAny(
-								*ovirtsdk4.NewDiskAttachmentBuilder().
+								ovirtsdk4.NewDiskAttachmentBuilder().
 									Disk(
 										ovirtsdk4.NewDiskBuilder().
 											Id(disk.MustId()).
 											Format(ovirtsdk4.DISKFORMAT_COW).
 											StorageDomainsOfAny(
-												*ovirtsdk4.NewStorageDomainBuilder().
+												ovirtsdk4.NewStorageDomainBuilder().
 													Id(sd.MustId()).
 													MustBuild()).
 											MustBuild()).

--- a/sdk/examples/add_vm_nic.go
+++ b/sdk/examples/add_vm_nic.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addVMNic() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/add_vm_snapshot.go
+++ b/sdk/examples/add_vm_snapshot.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addVMSnapshot() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/add_vm_with_sysprep.go
+++ b/sdk/examples/add_vm_with_sysprep.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addVMWithSysprep() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -79,15 +79,8 @@ func main() {
 		}
 		getResp, _ := vmService.Get().Send()
 		vm, _ := getResp.Vm()
+		vm.MustId()
 	}
-
-	// The content of the Unattend.xml file. Note that this is an incomplete file, make sure to use a complete one,
-	// maybe reading it from an external file:
-	unattendXML :=
-		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-			"<unattend xmlns=\"urn:schemas-microsoft-com:unattend\">\n" +
-			"  ...\n" +
-			"</unattend>\n"
 
 	// Start the virtual machine enabling Sysprep. Make sure to use a Windows operating system, either in the
 	// template, or overriding it explicitly here. Without that the Sysprep logic won't be triggered.

--- a/sdk/examples/add_vnc_console.go
+++ b/sdk/examples/add_vnc_console.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func addVNCConsole() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -65,7 +65,7 @@ func main() {
 	var console *ovirtsdk4.GraphicsConsole
 	for _, c := range consoleSlice.Slice() {
 		if c.MustProtocol() == ovirtsdk4.GRAPHICSTYPE_VNC {
-			*console = c
+			console = c
 		}
 	}
 

--- a/sdk/examples/assign_affinity_label_to_vm.go
+++ b/sdk/examples/assign_affinity_label_to_vm.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func assignAffinityLabelToVM() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 	// Create the connection to the server
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/assign_network_to_cluster.go
+++ b/sdk/examples/assign_network_to_cluster.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func assignNetworkToCluster() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 	// Create the connection to the server
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/assign_tag_to_vm.go
+++ b/sdk/examples/assign_tag_to_vm.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func assignTagToVM() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 	// Create the connection to the server:
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/attach_nfs_data_storage_domain.go
+++ b/sdk/examples/attach_nfs_data_storage_domain.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func attachNFSDataStorageDomain() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 	// Create the connection to the server:
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/attach_nfs_iso_storage_domain.go
+++ b/sdk/examples/attach_nfs_iso_storage_domain.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func attachISODataStorageDomain() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 	// Create the connection to the server:
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/change_vm_cd.go
+++ b/sdk/examples/change_vm_cd.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func changeVMCd() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 	// Create the connection to the server:
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/clone_vm_from_snapshot.go
+++ b/sdk/examples/clone_vm_from_snapshot.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func cloneVMFromSnapshot() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 	// Create the connection to the server:
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -66,7 +66,7 @@ func main() {
 	var snap *ovirtsdk4.Snapshot
 	for _, sn := range snapSlice.Slice() {
 		if sn.MustDescription() == "mysnap" {
-			snap = &sn
+			snap = sn
 		}
 	}
 

--- a/sdk/examples/enable_serial_console.go
+++ b/sdk/examples/enable_serial_console.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func enableSerialConsole() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 	// Create the connection to the server:
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/export_vm.go
+++ b/sdk/examples/export_vm.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func exportVM() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 	// Create the connection to the server:
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/follow_vm_links.go
+++ b/sdk/examples/follow_vm_links.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func followVMLinks() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 	// Create the connection to the server:
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/import_glance_image.go
+++ b/sdk/examples/import_glance_image.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func importGlanceImage() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 	// Create the connection to the server:
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -70,7 +70,7 @@ func main() {
 	var image *ovirtsdk4.Image
 	for _, img := range imageSlice.Slice() {
 		if img.MustName() == "CirrOS 0.3.4 for x86_64" {
-			image = &img
+			image = img
 			break
 		}
 	}

--- a/sdk/examples/import_vm.go
+++ b/sdk/examples/import_vm.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func importVM() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 	// Create the connection to the server:
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -96,7 +96,7 @@ func main() {
 				MustBuild()).
 		Vm(
 			ovirtsdk4.NewVmBuilder().
-				Id(exportedVM.MustId).
+				Id(exportedVM.MustId()).
 				MustBuild()).
 		MustSend()
 }

--- a/sdk/examples/list_affinity_labels.go
+++ b/sdk/examples/list_affinity_labels.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func listAffinityLabels() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -78,7 +78,7 @@ func main() {
 			}
 			if vms, ok := vms.(*ovirtsdk4.VmSlice); ok {
 				for _, vmLink := range vms.Slice() {
-					vm, err := conn.FollowLink(&vmLink)
+					vm, err := conn.FollowLink(vmLink)
 					if err != nil {
 						fmt.Printf("Failed to follow vm link: %v, reason: %v\n", vmLink.MustHref(), err)
 						return

--- a/sdk/examples/list_clusters.go
+++ b/sdk/examples/list_clusters.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func listClusters() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/list_datacenters.go
+++ b/sdk/examples/list_datacenters.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func listDatacenters() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/list_glance_images.go
+++ b/sdk/examples/list_glance_images.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func listGlanceImages() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/list_hosts_statistics.go
+++ b/sdk/examples/list_hosts_statistics.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func listHostsStatistics() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/list_roles.go
+++ b/sdk/examples/list_roles.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func listRoles() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/list_vm_disks.go
+++ b/sdk/examples/list_vm_disks.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func listVMDisks() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/list_vm_snapshots.go
+++ b/sdk/examples/list_vm_snapshots.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func listVMSnapshots() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/list_vm_tags.go
+++ b/sdk/examples/list_vm_tags.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func listVMTags() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/list_vms.go
+++ b/sdk/examples/list_vms.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func listVMs() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/pin_vm.go
+++ b/sdk/examples/pin_vm.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func pinVM() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -63,7 +63,7 @@ func main() {
 				PlacementPolicy(
 					ovirtsdk4.NewVmPlacementPolicyBuilder().
 						HostsOfAny(
-							*ovirtsdk4.NewHostBuilder().
+							ovirtsdk4.NewHostBuilder().
 								Name("myhost").
 								MustBuild()).
 						MustBuild()).

--- a/sdk/examples/register_vm.go
+++ b/sdk/examples/register_vm.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func registerVM() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -64,7 +64,7 @@ func main() {
 	var vm *ovirtsdk4.Vm
 	for _, v := range unregVMSlice.Slice() {
 		if v.MustName() == "myvm" {
-			vm = &v
+			vm = v
 			break
 		}
 	}
@@ -84,7 +84,7 @@ func main() {
 				Name("mycluster").
 				MustBuild()).
 		VnicProfileMappingsOfAny(
-			*ovirtsdk4.NewVnicProfileMappingBuilder().
+			ovirtsdk4.NewVnicProfileMappingBuilder().
 				SourceNetworkName("mynetwork").
 				SourceNetworkProfileName("mynetwork").
 				TargetVnicProfile(

--- a/sdk/examples/remove_host.go
+++ b/sdk/examples/remove_host.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func removeHost() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/remove_tag.go
+++ b/sdk/examples/remove_tag.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func removeTag() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/remove_vm.go
+++ b/sdk/examples/remove_vm.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func removeVM() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/search_vms.go
+++ b/sdk/examples/search_vms.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func searchVM() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/set_vm_lease_storage_domain.go
+++ b/sdk/examples/set_vm_lease_storage_domain.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func setVMLeaseStorageDomain() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/start_vm.go
+++ b/sdk/examples/start_vm.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func startVM() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -54,7 +54,7 @@ func main() {
 	vm := vmsService.List().Search("name=myvm").MustSend().MustVms().Slice()[0]
 
 	// Locate the service that manages the virtual machine, as that is where the action methods are defined
-	vmService := vmsService.VmService()
+	vmService := vmsService.VmService(vm.MustId())
 
 	// Call the "start" method of the service to start it
 	vmService.Start().MustSend()

--- a/sdk/examples/start_vm_with_cloudinit.go
+++ b/sdk/examples/start_vm_with_cloudinit.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func startVMWithCloudinit() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -54,7 +54,7 @@ func main() {
 	vm := vmsService.List().Search("name=myvm").MustSend().MustVms().Slice()[0]
 
 	// Locate the service that manages the virtual machine, as that is where the action methods are defined
-	vmService := vmsService.VmService()
+	vmService := vmsService.VmService(vm.MustId())
 
 	// Create cloud-init script, which you want to execute in deployed virtual machine, please note that
 	// the script must be properly formatted and indented as it's using YAML.
@@ -76,7 +76,7 @@ func main() {
 						RootPassword("redhat123").
 						HostName("myvm.example.com").
 						NicConfigurationsOfAny(
-							*ovirtsdk4.NewNicConfigurationBuilder().
+							ovirtsdk4.NewNicConfigurationBuilder().
 								Name("eth0").
 								OnBoot(true).
 								BootProtocol(ovirtsdk4.BOOTPROTOCOL_STATIC).

--- a/sdk/examples/stop_vm.go
+++ b/sdk/examples/stop_vm.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func stopVM() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -54,7 +54,7 @@ func main() {
 	vm := vmsService.List().Search("name=myvm").MustSend().MustVms().Slice()[0]
 
 	// Locate the service that manages the virtual machine, as that is where the action methods are defined
-	vmService := vmsService.VmService()
+	vmService := vmsService.VmService(vm.MustId())
 
 	// Call the "stop" method of the service to stop it
 	vmService.Stop().MustSend()

--- a/sdk/examples/unassign_tag_to_vm.go
+++ b/sdk/examples/unassign_tag_to_vm.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func unassignTagToVM() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 	// Create the connection to the server:
 	conn, err := ovirtsdk4.NewConnectionBuilder().

--- a/sdk/examples/update_datacenter.go
+++ b/sdk/examples/update_datacenter.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func updateDatacenter() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -60,7 +60,7 @@ func main() {
 	// In order to update the data center we need a reference to the service that manages it, then we can call the
 	// "update" method passing the update
 	dcService := dcsService.DataCenterService(dc.MustId())
-	dc := dcService.Update().
+	dc = dcService.Update().
 		DataCenter(
 			ovirtsdk4.NewDataCenterBuilder().
 				Description("Updated description").

--- a/sdk/examples/update_fencing_options.go
+++ b/sdk/examples/update_fencing_options.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func updateFencingOptions() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -71,7 +71,7 @@ func main() {
 	var agent *ovirtsdk4.Agent
 	for _, ag := range agentSlice.Slice() {
 		if ag.MustType() == "ipmlan" {
-			agent = &ag
+			agent = ag
 			break
 		}
 	}
@@ -84,7 +84,7 @@ func main() {
 
 	// Create a list of modified options, containing all the original options except the one with the name we want
 	// to modify, as we will add that with the right value later
-	var modifiedList []ovirtsdk4.Option
+	var modifiedList []*ovirtsdk4.Option
 	for _, ori := range optionSlice.Slice() {
 		if name != ori.MustName() {
 			modifiedList = append(modifiedList, ori)

--- a/sdk/examples/update_quota_limits.go
+++ b/sdk/examples/update_quota_limits.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func main() {
+func updateQuotaLimits() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -67,6 +67,7 @@ func main() {
 		MustStorageDomains().
 		Slice()[0]
 	sdService := sdsService.StorageDomainService(sd.MustId())
+	sdService.ImagesService()
 
 	// Find the quota and the service that manages it. Note that the service that manages the quota doesn't support
 	// search, so we need to retrieve all the quotas and filter explicitly. If the quota doesn't exist, create it.
@@ -75,7 +76,7 @@ func main() {
 	var quota *ovirtsdk4.Quota
 	for _, q := range quotaSlice.Slice() {
 		if q.MustId() == "myquota" {
-			quota = &q
+			quota = q
 			break
 		}
 	}
@@ -101,7 +102,7 @@ func main() {
 	var limit *ovirtsdk4.QuotaStorageLimit
 	for _, l := range limitSlice.Slice() {
 		if l.MustId() == sd.MustId() {
-			limit = &l
+			limit = l
 			break
 		}
 	}


### PR DESCRIPTION
The old codes I wrote were bad and unidiomatic. While the reason is that I knew little about the oVirt engine API model/metamodel before. Now I refactor the whole project after some days, which mainly contains these changes:
1. Optimize code/file structures;
2. Re-implement ugly codes;
3. Redesign some type structures;

The newly generated go sdk has one backward incompatible change, which is using slice of pointers as the `ListType` attributes in the `*Type*Slice` definitions.

```go
type VmSlice struct {
	href  *string
	slice []Vm
}
```
now changes to:
```go
type VmSlice struct {
	href  *string
	slice []*Vm
}
```

The examples have also been updated and with some bug fixes.
