### PR TITLE
Assigns to ActionBuilder attributes only when the input params are not nil.

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/go/ServicesGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/ServicesGenerator.java
@@ -497,7 +497,9 @@ public class ServicesGenerator implements GoGenerator {
                 String paraArgName = goNames.getParameterStyleName(parameter.getName());
                 String paraMethodName = goNames.getExportableMemberStyleName(parameter.getName());
                 if (goTypes.isGoPrimitiveType(parameter.getType())) {
-                    buffer.addLine("actionBuilder.%1$s(*p.%2$s);", paraMethodName, paraArgName);
+                    buffer.addLine("if p.%1$s != nil {", paraArgName);
+                    buffer.addLine("  actionBuilder.%1$s(*p.%2$s);", paraMethodName, paraArgName);
+                    buffer.addLine("}");
                 } else {
                     buffer.addLine("actionBuilder.%1$s(p.%2$s);", paraMethodName, paraArgName);
                 }


### PR DESCRIPTION
### Description of the Change

Fixes the bug of panics when starting a vm. Do make attribute assignments only when the input params not nil. 

The generated codes changes mainly from:

```go
        actionBuilder.Async(*p.async)
```

to

```go
	if p.async != nil {
		actionBuilder.Async(*p.async)
	}
```

This change also applies to every `ActionBuilder` attributes assignments in building every action request, which could avoid panics when `p.async` is `nil`.

### Applicable Issues

Fixes #107 .