### PR TITLE
Remove main() function from examples files, thus adding more examples.

### DIFF
--- a/sdk/examples/list_operating_systems.go
+++ b/sdk/examples/list_operating_systems.go
@@ -23,8 +23,8 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func addGroup() {
-	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+func listOperationSystem() {
+	inputRawURL := "https://10.1.111.222/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
 		URL(inputRawURL).
@@ -47,23 +47,10 @@ func addGroup() {
 		}
 	}()
 
-	// Get the reference to the groups service
-	groupsService := conn.SystemService().GroupsService()
-
-	// Use the "add" method to add group from a directory service. Please note that domain name is name of the
-	// authorization provider
-	_, err = groupsService.Add().
-		Group(
-			ovirtsdk4.NewGroupBuilder().
-				Name("Developers").
-				Domain(
-					ovirtsdk4.NewDomainBuilder().
-						Name("internal-authz").
-						MustBuild()).
-				MustBuild()).
-		Send()
-	if err != nil {
-		fmt.Printf("Failed to add group, reason: %v\n", err)
-		return
+	ossService := conn.SystemService().OperatingSystemsService()
+	listResp := ossService.List().MustSend()
+	fmt.Printf("os are:\n")
+	for _, item := range listResp.MustOperatingSystem().Slice() {
+		fmt.Printf("id:%v, name:%v, href:%v\n", item.MustId(), item.MustName(), item.MustHref())
 	}
 }

--- a/sdk/examples/list_storage_domains.go
+++ b/sdk/examples/list_storage_domains.go
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
-func addGroup() {
+func listStorageDomains() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -47,23 +47,14 @@ func addGroup() {
 		}
 	}()
 
-	// Get the reference to the groups service
-	groupsService := conn.SystemService().GroupsService()
-
-	// Use the "add" method to add group from a directory service. Please note that domain name is name of the
-	// authorization provider
-	_, err = groupsService.Add().
-		Group(
-			ovirtsdk4.NewGroupBuilder().
-				Name("Developers").
-				Domain(
-					ovirtsdk4.NewDomainBuilder().
-						Name("internal-authz").
-						MustBuild()).
-				MustBuild()).
-		Send()
+	sdsListResp, err := conn.SystemService().StorageDomainsService().List().Send()
 	if err != nil {
-		fmt.Printf("Failed to add group, reason: %v\n", err)
+		fmt.Printf("Failed to get storage domains, reason: %v\n", err)
 		return
 	}
+
+	for _, sds := range sdsListResp.MustStorageDomains().Slice() {
+		fmt.Printf("id: %v", sds.MustId())
+	}
+
 }


### PR DESCRIPTION
### Description of the Change

Remove `main` function from the `add_group.go`, so you could write your own `main.go` to run the example. Also add more examples of `add_disk`, `list_storage_domains`,  `list_operating_system`.

