### PR TITLE
Better handling error response with empty content

### DIFF
--- a/sdk/ovirtsdk/service.go
+++ b/sdk/ovirtsdk/service.go
@@ -51,6 +51,10 @@ func CheckFault(response *http.Response) error {
 	if err != nil {
 		return fmt.Errorf("Failed to read response, reason: %s", err.Error())
 	}
+	// Process empty response body
+	if len(resBytes) == 0 {
+		return BuildError(response, nil)
+	}
 
 	reader := NewXMLReader(resBytes)
 	fault, err := XMLFaultReadOne(reader, nil, "")
@@ -72,6 +76,10 @@ func CheckAction(response *http.Response) (*Action, error) {
 	resBytes, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read response, reason: %s", err.Error())
+	}
+	// Process empty response body
+	if len(resBytes) == 0 {
+		return nil, BuildError(response, nil)
 	}
 
 	faultreader := NewXMLReader(resBytes)


### PR DESCRIPTION
### Description of the Change

The error `Failed to find StartElement` was caused by parsing empty string to XML format. The solution is before parsing response body by XML parser, check if the body is empty. If empty, call the function `BuildError(response, nil)` 

### Benefits

Intuitive error message will be shown to the SDK callers.

### Verification Process

The same code as described in #112  should output `error is HTTP response code is "405". HTTP response message is "405 Method Not Allowed"`.

### Applicable Issues

#112 .