### PR TITLE
Use RFC3339Nano to parse and format time

### DIFF
--- a/sdk/ovirtsdk/reader.go
+++ b/sdk/ovirtsdk/reader.go
@@ -234,7 +234,8 @@ func (reader *XMLReader) ReadTime(start *xml.StartElement) (time.Time, error) {
 		var t time.Time
 		return t, err
 	}
-	return time.Parse("2006-01-02T15:04:05.999999-07:00", str)
+	
+	return time.Parse(time.RFC3339Nano, str)
 }
 
 func (reader *XMLReader) ReadTimes(start *xml.StartElement) ([]time.Time, error) {
@@ -244,7 +245,7 @@ func (reader *XMLReader) ReadTimes(start *xml.StartElement) ([]time.Time, error)
 	}
 	var times []time.Time
 	for _, sv := range strs {
-		tv, err := time.Parse("2006-01-02T15:04:05.999999-07:00", sv)
+		tv, err := time.Parse(time.RFC3339Nano, sv)
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/ovirtsdk/writer.go
+++ b/sdk/ovirtsdk/writer.go
@@ -177,7 +177,7 @@ func (writer *XMLWriter) WriteDates(name string, ts []time.Time) error {
 }
 
 func (writer *XMLWriter) FormatDate(t time.Time) string {
-	return t.Format("2006-01-02T15:04:05.999999")
+	return t.Format(time.RFC3339Nano)
 }
 
 func (writer *XMLWriter) EscapeString(s string) {


### PR DESCRIPTION
### Description of the Change

Use `time.RFC3339Nano` format to parse/format a time string.

### Applicable Issues

The `XMLReader.ReadTime` could not parse the VM creation time of a Z for the UTC timezone, see #116 for detail.