### PR TITLE
Also use RFC3339Nano in the generator (issue #116)

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/go/ReadersGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/ReadersGenerator.java
@@ -343,7 +343,7 @@ public class ReadersGenerator implements GoGenerator {
             }
             else if (memberType == model.getDateType()) {
                 buffer.addImport("time");
-                buffer.addLine("        builder.%1$s(time.Parse(\"2006-01-02T15:04:05.999999\", value))", publicMethodName);
+                buffer.addLine("        builder.%1$s(time.Parse(time.RFC3339Nano, value))", publicMethodName);
                 buffer.addLine("        if err != nil {");
                 buffer.addLine("          return nil, err");
                 buffer.addLine("        }");


### PR DESCRIPTION
### Description of the Change
PR #117 fixed the format string used for parsing time strings in the Go source code. The generator code also includes a copy of the erroneous format string. As it doesn't end up in the generated Go code, this has no effect on functionality. Future changes to the model may cause this to change, so don't leave this possible landmine behind.

### Applicable Issues
Issue #116