### PR TITLE
Use `examples` as the package name of examples codes

### DIFF
--- a/sdk/examples/add_affinity_label.go
+++ b/sdk/examples/add_affinity_label.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_bond.go
+++ b/sdk/examples/add_bond.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_datacenter.go
+++ b/sdk/examples/add_datacenter.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_disk.go
+++ b/sdk/examples/add_disk.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"bytes"

--- a/sdk/examples/add_floating_disk.go
+++ b/sdk/examples/add_floating_disk.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_group.go
+++ b/sdk/examples/add_group.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_host.go
+++ b/sdk/examples/add_host.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_independent_vm.go
+++ b/sdk/examples/add_independent_vm.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_instance_type.go
+++ b/sdk/examples/add_instance_type.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_logical_network.go
+++ b/sdk/examples/add_logical_network.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_lun_disk_to_vm.go
+++ b/sdk/examples/add_lun_disk_to_vm.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_mac_pool.go
+++ b/sdk/examples/add_mac_pool.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_nfs_data_storage_domain.go
+++ b/sdk/examples/add_nfs_data_storage_domain.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_nfs_iso_storage_domain.go
+++ b/sdk/examples/add_nfs_iso_storage_domain.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_tag.go
+++ b/sdk/examples/add_tag.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_template.go
+++ b/sdk/examples/add_template.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_user_public_sshkey.go
+++ b/sdk/examples/add_user_public_sshkey.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_vm.go
+++ b/sdk/examples/add_vm.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_vm_disk.go
+++ b/sdk/examples/add_vm_disk.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_vm_from_template.go
+++ b/sdk/examples/add_vm_from_template.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_vm_nic.go
+++ b/sdk/examples/add_vm_nic.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_vm_snapshot.go
+++ b/sdk/examples/add_vm_snapshot.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_vm_with_sysprep.go
+++ b/sdk/examples/add_vm_with_sysprep.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/add_vnc_console.go
+++ b/sdk/examples/add_vnc_console.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/assign_affinity_label_to_vm.go
+++ b/sdk/examples/assign_affinity_label_to_vm.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/assign_network_to_cluster.go
+++ b/sdk/examples/assign_network_to_cluster.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/assign_tag_to_vm.go
+++ b/sdk/examples/assign_tag_to_vm.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/attach_nfs_data_storage_domain.go
+++ b/sdk/examples/attach_nfs_data_storage_domain.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/attach_nfs_iso_storage_domain.go
+++ b/sdk/examples/attach_nfs_iso_storage_domain.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/change_vm_cd.go
+++ b/sdk/examples/change_vm_cd.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/clone_vm_from_snapshot.go
+++ b/sdk/examples/clone_vm_from_snapshot.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/enable_serial_console.go
+++ b/sdk/examples/enable_serial_console.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/export_vm.go
+++ b/sdk/examples/export_vm.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/follow_vm_links.go
+++ b/sdk/examples/follow_vm_links.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/import_glance_image.go
+++ b/sdk/examples/import_glance_image.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/import_vm.go
+++ b/sdk/examples/import_vm.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/list_affinity_labels.go
+++ b/sdk/examples/list_affinity_labels.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/list_clusters.go
+++ b/sdk/examples/list_clusters.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/list_datacenters.go
+++ b/sdk/examples/list_datacenters.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/list_glance_images.go
+++ b/sdk/examples/list_glance_images.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/list_hosts_statistics.go
+++ b/sdk/examples/list_hosts_statistics.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/list_operating_systems.go
+++ b/sdk/examples/list_operating_systems.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/list_roles.go
+++ b/sdk/examples/list_roles.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/list_storage_domains.go
+++ b/sdk/examples/list_storage_domains.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/list_vm_disks.go
+++ b/sdk/examples/list_vm_disks.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/list_vm_snapshots.go
+++ b/sdk/examples/list_vm_snapshots.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/list_vm_tags.go
+++ b/sdk/examples/list_vm_tags.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/list_vms.go
+++ b/sdk/examples/list_vms.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/pin_vm.go
+++ b/sdk/examples/pin_vm.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/register_vm.go
+++ b/sdk/examples/register_vm.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/remove_host.go
+++ b/sdk/examples/remove_host.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/remove_tag.go
+++ b/sdk/examples/remove_tag.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/remove_vm.go
+++ b/sdk/examples/remove_vm.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/search_vms.go
+++ b/sdk/examples/search_vms.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/set_vm_lease_storage_domain.go
+++ b/sdk/examples/set_vm_lease_storage_domain.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/start_vm.go
+++ b/sdk/examples/start_vm.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/start_vm_with_cloudinit.go
+++ b/sdk/examples/start_vm_with_cloudinit.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/stop_vm.go
+++ b/sdk/examples/stop_vm.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/unassign_tag_to_vm.go
+++ b/sdk/examples/unassign_tag_to_vm.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/update_datacenter.go
+++ b/sdk/examples/update_datacenter.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/update_fencing_options.go
+++ b/sdk/examples/update_fencing_options.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/update_quota_limits.go
+++ b/sdk/examples/update_quota_limits.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"

--- a/sdk/examples/wait_vm_status.go
+++ b/sdk/examples/wait_vm_status.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package main
+package examples
 
 import (
 	"fmt"


### PR DESCRIPTION
### Description of the Change

The package name of examples codes changed from `main` to `examples`. This would make example code be *importable*.

