### PR TITLE
Add support for parsing AuthError and NotFoundError

### DIFF
--- a/sdk/examples/process_errors.go
+++ b/sdk/examples/process_errors.go
@@ -1,0 +1,85 @@
+package examples
+
+import (
+	"fmt"
+	"time"
+
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func processAuthError() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("wrong-password"). // Incorrect password
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Get the reference to the "datacenters" service:
+	_, err = conn.SystemService().DataCentersService().List().Send()
+
+	if err != nil {
+		if _, ok := err.(*ovirtsdk4.AuthError); ok {
+			fmt.Printf("Failed to authenticate user\n")
+			return
+		}
+		fmt.Printf("Failed to get datacenter list, reason: %v\n", err)
+		return
+	}
+}
+
+func processNotFoundError() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("correct-password").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Get the reference to the "datacenters" service:
+	_, err = conn.SystemService().DataCentersService().
+		DataCenterService("not-exists").
+		Get().
+		Send()
+
+	if err != nil {
+		if _, ok := err.(*ovirtsdk4.NotFoundError); ok {
+			fmt.Printf("DataCenter not found\n")
+			return
+		}
+		fmt.Printf("Failed to get datacenter, reason: %v\n", err)
+		return
+	}
+}

--- a/sdk/ovirtsdk/error.go
+++ b/sdk/ovirtsdk/error.go
@@ -1,0 +1,141 @@
+package ovirtsdk
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type baseError struct {
+	Code int
+	Msg  string
+}
+
+func (b *baseError) Error() string {
+	return b.Msg
+}
+
+// AuthError indicates that an authentiation or authorization
+// problem happenend, like incorrect user name, incorrect password, or
+// missing permissions.
+type AuthError struct {
+	baseError
+}
+
+// NotFoundError indicates that an object can't be found.
+type NotFoundError struct {
+	baseError
+}
+
+// CheckFault procoesses error parsing and returns it back
+func CheckFault(response *http.Response) error {
+	resBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("Failed to read response, reason: %s", err.Error())
+	}
+	// Process empty response body
+	if len(resBytes) == 0 {
+		return BuildError(response, nil)
+	}
+
+	reader := NewXMLReader(resBytes)
+	fault, err := XMLFaultReadOne(reader, nil, "")
+	if err != nil {
+		// If the XML is not a <fault>, just return nil
+		if err, ok := err.(XMLTagNotMatchError); ok {
+			return err
+		}
+		return err
+	}
+	if fault != nil || response.StatusCode >= 400 {
+		return BuildError(response, fault)
+	}
+	return errors.New("unkonwn error")
+}
+
+// CheckAction checks if response contains an Action instance
+func CheckAction(response *http.Response) (*Action, error) {
+	resBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read response, reason: %s", err.Error())
+	}
+	// Process empty response body
+	if len(resBytes) == 0 {
+		return nil, BuildError(response, nil)
+	}
+
+	faultreader := NewXMLReader(resBytes)
+	fault, err := XMLFaultReadOne(faultreader, nil, "")
+	if err != nil {
+		// If the tag mismatches, return the err
+		if _, ok := err.(XMLTagNotMatchError); !ok {
+			return nil, err
+		}
+	}
+	if fault != nil {
+		return nil, BuildError(response, fault)
+	}
+
+	actionreader := NewXMLReader(resBytes)
+	action, err := XMLActionReadOne(actionreader, nil, "")
+	if err != nil {
+		// If the tag mismatches, return the err
+		if _, ok := err.(XMLTagNotMatchError); !ok {
+			return nil, err
+		}
+	}
+	if action != nil {
+		if afault, ok := action.Fault(); ok {
+			return nil, BuildError(response, afault)
+		}
+		return action, nil
+	}
+	return nil, nil
+}
+
+// BuildError constructs error
+func BuildError(response *http.Response, fault *Fault) error {
+	var buffer bytes.Buffer
+	if fault != nil {
+		if reason, ok := fault.Reason(); ok {
+			if buffer.Len() > 0 {
+				buffer.WriteString(" ")
+			}
+			buffer.WriteString(fmt.Sprintf("Fault reason is \"%s\".", reason))
+		}
+		if detail, ok := fault.Detail(); ok {
+			if buffer.Len() > 0 {
+				buffer.WriteString(" ")
+			}
+			buffer.WriteString(fmt.Sprintf("Fault detail is \"%s\".", detail))
+		}
+	}
+	if response != nil {
+		if buffer.Len() > 0 {
+			buffer.WriteString(" ")
+		}
+		buffer.WriteString(fmt.Sprintf("HTTP response code is \"%d\".", response.StatusCode))
+		buffer.WriteString(" ")
+		buffer.WriteString(fmt.Sprintf("HTTP response message is \"%s\".", response.Status))
+
+		if Contains(response.StatusCode, []int{401, 403}) {
+			return &AuthError{
+				baseError{
+					response.StatusCode,
+					buffer.String(),
+				},
+			}
+		} else if response.StatusCode == 404 {
+			return &NotFoundError{
+				baseError{
+					response.StatusCode,
+					buffer.String(),
+				},
+			}
+		}
+	}
+
+	return errors.New(buffer.String())
+}

--- a/sdk/ovirtsdk/service.go
+++ b/sdk/ovirtsdk/service.go
@@ -16,14 +16,6 @@
 
 package ovirtsdk
 
-import (
-	"bytes"
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-)
-
 // Service is the interface of all type services.
 type Service interface {
 	Connection() *Connection
@@ -43,99 +35,4 @@ func (service *baseService) Connection() *Connection {
 
 func (service *baseService) Path() string {
 	return service.path
-}
-
-// CheckFault procoesses error parsing and returns it back
-func CheckFault(response *http.Response) error {
-	resBytes, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return fmt.Errorf("Failed to read response, reason: %s", err.Error())
-	}
-	// Process empty response body
-	if len(resBytes) == 0 {
-		return BuildError(response, nil)
-	}
-
-	reader := NewXMLReader(resBytes)
-	fault, err := XMLFaultReadOne(reader, nil, "")
-	if err != nil {
-		// If the XML is not a <fault>, just return nil
-		if err, ok := err.(XMLTagNotMatchError); ok {
-			return err
-		}
-		return err
-	}
-	if fault != nil || response.StatusCode >= 400 {
-		return BuildError(response, fault)
-	}
-	return errors.New("unkonwn error")
-}
-
-// CheckAction checks if response contains an Action instance
-func CheckAction(response *http.Response) (*Action, error) {
-	resBytes, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to read response, reason: %s", err.Error())
-	}
-	// Process empty response body
-	if len(resBytes) == 0 {
-		return nil, BuildError(response, nil)
-	}
-
-	faultreader := NewXMLReader(resBytes)
-	fault, err := XMLFaultReadOne(faultreader, nil, "")
-	if err != nil {
-		// If the tag mismatches, return the err
-		if _, ok := err.(XMLTagNotMatchError); !ok {
-			return nil, err
-		}
-	}
-	if fault != nil {
-		return nil, BuildError(response, fault)
-	}
-
-	actionreader := NewXMLReader(resBytes)
-	action, err := XMLActionReadOne(actionreader, nil, "")
-	if err != nil {
-		// If the tag mismatches, return the err
-		if _, ok := err.(XMLTagNotMatchError); !ok {
-			return nil, err
-		}
-	}
-	if action != nil {
-		if afault, ok := action.Fault(); ok {
-			return nil, BuildError(response, afault)
-		}
-		return action, nil
-	}
-	return nil, nil
-}
-
-// BuildError constructs error
-func BuildError(response *http.Response, fault *Fault) error {
-	var buffer bytes.Buffer
-	if fault != nil {
-		if reason, ok := fault.Reason(); ok {
-			if buffer.Len() > 0 {
-				buffer.WriteString(" ")
-			}
-			buffer.WriteString(fmt.Sprintf("Fault reason is \"%s\".", reason))
-		}
-		if detail, ok := fault.Detail(); ok {
-			if buffer.Len() > 0 {
-				buffer.WriteString(" ")
-			}
-			buffer.WriteString(fmt.Sprintf("Fault detail is \"%s\".", detail))
-		}
-	}
-	if response != nil {
-		if buffer.Len() > 0 {
-			buffer.WriteString(" ")
-		}
-		buffer.WriteString(fmt.Sprintf("HTTP response code is \"%d\".", response.StatusCode))
-		buffer.WriteString(" ")
-		buffer.WriteString(fmt.Sprintf("HTTP response message is \"%s\".", response.Status))
-	}
-
-	return errors.New(buffer.String())
 }


### PR DESCRIPTION
### Description of the Change

Add `AuthError` and `NotFoundErr` types. Before returning the generic error which only contains a message, try to parse into `AuthError` or `NotFoundError` with `Code` and `Msg` fields in.


### Benefits

Users could identify these two error types by type assertions.

```go
if err404, ok := err.(*ovirtsdk4.NotFoundError); ok {
    // ...
}
```
