### PR TITLE
Fix the bug that failed to parse gluster bricks XML response

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/go/ReadersGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/ReadersGenerator.java
@@ -285,7 +285,8 @@ public class ReadersGenerator implements GoGenerator {
         buffer.addLine("    switch t := t.(type) {");
         buffer.addLine("    case xml.StartElement:");
         String singularTag = goNames.getTagStyleName(type.getName());
-        buffer.addLine("      if t.Name.Local == \"%1$s\" {", singularTag);
+        buffer.addLine("      switch t.Name.Local {");
+        buffer.addLine("      case \"%1$s\":", singularTag);
         buffer.addLine("        one, err := %1$s(reader, &t, \"%2$s\")", goTypes.getXmlReadOneFuncName(type).getSimpleName(), singularTag);
         buffer.addLine("        if err != nil {");
         buffer.addLine("          return nil, err");
@@ -293,6 +294,8 @@ public class ReadersGenerator implements GoGenerator {
         buffer.addLine("        if one != nil {");
         buffer.addLine("          result.slice = append(result.slice, one)");
         buffer.addLine("        }");
+        buffer.addLine("      default:");
+        buffer.addLine("        reader.Skip()");
         buffer.addLine("      }");
         buffer.addLine("	case xml.EndElement:");
         buffer.addLine("      depth--");

--- a/sdk/ovirtsdk/readers_test.go
+++ b/sdk/ovirtsdk/readers_test.go
@@ -244,3 +244,34 @@ func TestFaultReadOne(t *testing.T) {
 	assert.Equal("architectures", err2.ActualTag)
 	assert.Equal("fault", err2.ExpectedTag)
 }
+
+// To cover the issue: https://github.com/imjoey/ovirt-engine-sdk-go/issues/121
+func TestGlusterBrickReadMany(t *testing.T) {
+	assert := assert.New(t)
+	xmlstring := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<bricks>
+	<actions>
+		<link href="/ovirt-engine/api/clusters/5b6d20ce-00b5-019a-02d2-00000000037c/glustervolumes/c667523c-7b0d-4602-82ff-3a721e760835/glusterbricks/migrate" rel="migrate"/>
+		<link href="/ovirt-engine/api/clusters/5b6d20ce-00b5-019a-02d2-00000000037c/glustervolumes/c667523c-7b0d-4602-82ff-3a721e760835/glusterbricks/stopmigrate" rel="stopmigrate"/>
+		<link href="/ovirt-engine/api/clusters/5b6d20ce-00b5-019a-02d2-00000000037c/glustervolumes/c667523c-7b0d-4602-82ff-3a721e760835/glusterbricks/activate" rel="activate"/>
+	</actions>
+	<brick href="/ovirt-engine/api/clusters/5b6d20ce-00b5-019a-02d2-00000000037c/glustervolumes/c667523c-7b0d-4602-82ff-3a721e760835/glusterbricks/06de18a8-8534-4ce4-9328-ff487ac1355f" id="06de18a8-8534-4ce4-9328-ff487ac1355f">
+		<actions>
+			<link href="/ovirt-engine/api/clusters/5b6d20ce-00b5-019a-02d2-00000000037c/glustervolumes/c667523c-7b0d-4602-82ff-3a721e760835/glusterbricks/06de18a8-8534-4ce4-9328-ff487ac1355f/replace" rel="replace"/>
+		</actions>
+		<name>10.1.87.223:/tt112</name>
+		<link href="/ovirt-engine/api/clusters/5b6d20ce-00b5-019a-02d2-00000000037c/glustervolumes/c667523c-7b0d-4602-82ff-3a721e760835/glusterbricks/06de18a8-8534-4ce4-9328-ff487ac1355f/statistics" rel="statistics"/>
+		<brick_dir>/tt112</brick_dir>
+		<server_id>75b39f00-fa03-410c-b29c-db80cf162a87</server_id>
+		<status>up</status>
+		<gluster_volume href="/ovirt-engine/api/clusters/5b6d20ce-00b5-019a-02d2-00000000037c/glustervolumes/c667523c-7b0d-4602-82ff-3a721e760835" id="c667523c-7b0d-4602-82ff-3a721e760835"/>
+	</brick>
+</bricks>
+`
+	reader := NewXMLReader([]byte(xmlstring))
+	bricks, err := XMLGlusterBrickReadMany(reader, nil)
+	assert.Nil(err)
+	assert.NotNil(bricks)
+	assert.Equal(1, len(bricks.Slice()))
+
+}


### PR DESCRIPTION
### Description of the Change

As described in issue #121 , if the XML returned is not as usual, parsing method would be failed to get the gluster bricks out. So the changes proposed in this pull request:

* Use `reader.skip()` to ignore the unexpected element to keep on walking through the XML which represents a list of entities.
* Add this to test case for better unit-test coverage

### Applicable Issues

Fixes #121 .