### PR TITLE
Fix some typos according to Go-Report-Card results.

### DIFF
--- a/sdk/examples/add_affinity_label.go
+++ b/sdk/examples/add_affinity_label.go
@@ -60,5 +60,5 @@ func addAffinityLabel() {
 		return
 	}
 	addedLabel, _ := resp.Label()
-	fmt.Printf("Affinity label with name (%v) added successfuly\n", addedLabel.MustName())
+	fmt.Printf("Affinity label with name (%v) added successfully\n", addedLabel.MustName())
 }

--- a/sdk/examples/add_tag.go
+++ b/sdk/examples/add_tag.go
@@ -63,11 +63,11 @@ func addTag() {
 		return
 	}
 	tagAdded, _ := resp.Tag()
-	fmt.Printf("Tag with name-(%v) and desc-(%v) added successfuly\n",
+	fmt.Printf("Tag with name-(%v) and desc-(%v) added successfully\n",
 		tagAdded.MustName(), tagAdded.MustDescription())
 
-	// If tag added successfuly, print out:
-	// 		`Tag with name-(mytag) and desc-(mytag desc) added successfuly`
+	// If tag added successfully, print out:
+	// 		`Tag with name-(mytag) and desc-(mytag desc) added successfully`
 	// If failed due to duplicate name, print out:
 	// 		`Failed to create a tag, reason: Fault reason is "Operation Failed".
 	// 		Fault detail is "[The specified Tag name already exists.]".

--- a/sdk/examples/assign_affinity_label_to_vm.go
+++ b/sdk/examples/assign_affinity_label_to_vm.go
@@ -99,5 +99,5 @@ func assignAffinityLabelToVM() {
 		fmt.Printf("Failed to assign affinity label to vm, reason: %v\n", err)
 		return
 	}
-	fmt.Printf("Assign affinity label (myaffinitylabel) to vm (%v) successfuly\n", vm.MustId())
+	fmt.Printf("Assign affinity label (myaffinitylabel) to vm (%v) successfully\n", vm.MustId())
 }

--- a/sdk/ovirtsdk/error.go
+++ b/sdk/ovirtsdk/error.go
@@ -18,7 +18,7 @@ func (b *baseError) Error() string {
 }
 
 // AuthError indicates that an authentiation or authorization
-// problem happenend, like incorrect user name, incorrect password, or
+// problem happened, like incorrect user name, incorrect password, or
 // missing permissions.
 type AuthError struct {
 	baseError
@@ -52,7 +52,7 @@ func CheckFault(response *http.Response) error {
 	if fault != nil || response.StatusCode >= 400 {
 		return BuildError(response, fault)
 	}
-	return errors.New("unkonwn error")
+	return errors.New("unknown error")
 }
 
 // CheckAction checks if response contains an Action instance


### PR DESCRIPTION
### Description of the Change

According to the results generated by Go Report Card service, fixed some typos below:

* `happenend` to `happened`
*  `unkonwn` to `unknown`
* `successfuly` to `successfully`
