### PR TITLE
Add headers param to oVirt connection

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/go/ServicesGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/ServicesGenerator.java
@@ -606,6 +606,7 @@ public class ServicesGenerator implements GoGenerator {
         String serviceClassName = getServiceName(service).getSimpleName();
         String serviceAsPrivateMemberName = serviceClassName;
         
+        injectConnectionHeaders(serviceAsPrivateMemberName);
         generateAdditionalHeadersParameters();
         buffer.addLine("req.Header.Add(\"User-Agent\", fmt.Sprintf(\"GoSDK/%%s\", SDK_VERSION))");
         buffer.addLine("req.Header.Add(\"Version\", \"4\")");
@@ -706,6 +707,14 @@ public class ServicesGenerator implements GoGenerator {
 
         buffer.addLine("return &%1$s{%2$s: result}, nil",
             response, goNames.getUnexportableMemberStyleName(parameter.getName()));
+    }
+
+    private void injectConnectionHeaders(String service) {
+        buffer.addLine();
+        buffer.addLine("for hk, hv := range p.%1$s.connection.headers {", service);
+        buffer.addLine(  "req.Header.Add(hk, hv)");
+        buffer.addLine("}");
+        buffer.addLine();
     }
 
     private void generateAdditionalHeadersParameters() {

--- a/sdk/ovirtsdk/connection.go
+++ b/sdk/ovirtsdk/connection.go
@@ -44,6 +44,7 @@ type Connection struct {
 	token    string
 	insecure bool
 	caFile   string
+	headers  map[string]string
 	kerberos bool
 	timeout  time.Duration
 	compress bool
@@ -433,6 +434,23 @@ func (connBuilder *ConnectionBuilder) CAFile(caFilePath string) *ConnectionBuild
 	return connBuilder
 }
 
+// Headers sets a map of custom HTTP headers to be added to each HTTP request
+func (connBuilder *ConnectionBuilder) Headers(headers map[string]string) *ConnectionBuilder {
+	// If already has errors, just return
+	if connBuilder.err != nil {
+		return connBuilder
+	}
+
+	if connBuilder.conn.headers == nil {
+		connBuilder.conn.headers = map[string]string{}
+	}
+
+	for hk, hv := range headers {
+		connBuilder.conn.headers[hk] = hv
+	}
+	return connBuilder
+}
+
 // Kerberos sets the kerberos field for `Connection` instance
 func (connBuilder *ConnectionBuilder) Kerberos(kerbros bool) *ConnectionBuilder {
 	// If already has errors, just return
@@ -458,7 +476,7 @@ func (connBuilder *ConnectionBuilder) Compress(compress bool) *ConnectionBuilder
 	return connBuilder
 }
 
-// Build contructs the `Connection` instance
+// Build constructs the `Connection` instance
 func (connBuilder *ConnectionBuilder) Build() (*Connection, error) {
 	// If already has errors, just return
 	if connBuilder.err != nil {


### PR DESCRIPTION
### Description of the Change
I'm opening this PR because of the fact that I need oVirt terraform provider to work also with non-admin credentials.

As a matter of fact, in this specific case each request to oVirt APIs should contain a `Filter: true` header in order to let oVirt know that we want the results to be filtered based on user permissions (see [this](https://lists.ovirt.org/pipermail/users/2016-June/040262.html) and [this](https://bugzilla.redhat.com/show_bug.cgi?id=1427987)).