### PR TITLE
Add support for logging http request/response details in connection

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/go/ServicesGenerator.java
+++ b/generator/src/main/java/org/ovirt/sdk/go/ServicesGenerator.java
@@ -629,6 +629,20 @@ public class ServicesGenerator implements GoGenerator {
         buffer.addLine("}");;
         buffer.addLine("defer resp.Body.Close()");
 
+        // Dump the request/response for debuging
+        buffer.addImport("net/http/httputil");
+        buffer.addLine("if p.%1$s.connection.logFunc != nil {", serviceAsPrivateMemberName);
+        buffer.addLine("  dumpReq, err := httputil.DumpRequestOut(req, true)");
+        buffer.addLine("  if err != nil {");
+        buffer.addLine("    return nil, err");
+        buffer.addLine("  }");
+        buffer.addLine("  dumpResp, err := httputil.DumpResponse(resp, true)");
+        buffer.addLine("  if err != nil {");
+        buffer.addLine("    return nil, err");
+        buffer.addLine("  }");
+        buffer.addLine("  p.%1$s.connection.logFunc(\"<<<<<<Request:\\n%%sResponse:\\n%%s>>>>>>\\n\", string(dumpReq), string(dumpResp))", serviceAsPrivateMemberName);
+        buffer.addLine("}");
+
         // Check the response status code
         if (codes != null && codes.length > 0) {
             buffer.addLine("if !Contains(resp.StatusCode, []int{%1$s}) {", String.join(",", codes));

--- a/sdk/ovirtsdk/connection.go
+++ b/sdk/ovirtsdk/connection.go
@@ -34,6 +34,9 @@ import (
 	"time"
 )
 
+// LogFunc represents a flexiable and injectable logger function which fits to most of logger libraries
+type LogFunc func(format string, v ...interface{})
+
 // Connection represents an HTTP connection to the engine server.
 // It is intended as the entry point for the SDK, and it provides access to the `system` service and, from there,
 // to the rest of the services provided by the API.
@@ -45,6 +48,9 @@ type Connection struct {
 	insecure bool
 	caFile   string
 	headers  map[string]string
+	// Debug options
+	logFunc LogFunc
+
 	kerberos bool
 	timeout  time.Duration
 	compress bool
@@ -61,7 +67,7 @@ func (c *Connection) URL() string {
 }
 
 // Test tests the connectivity with the server using the credentials provided in connection.
-// If connectivity works correctly and the credentials are valid, it returns a nil error, 
+// If connectivity works correctly and the credentials are valid, it returns a nil error,
 // or it will return an error containing the reason as the message.
 func (c *Connection) Test() error {
 	_, err := c.authenticate()
@@ -413,6 +419,16 @@ func (connBuilder *ConnectionBuilder) Insecure(insecure bool) *ConnectionBuilder
 		return connBuilder
 	}
 	connBuilder.conn.insecure = insecure
+	return connBuilder
+}
+
+// LogFunc sets the logging function field for `Connection` instance
+func (connBuilder *ConnectionBuilder) LogFunc(logFunc LogFunc) *ConnectionBuilder {
+	// If already has errors, just return
+	if connBuilder.err != nil {
+		return connBuilder
+	}
+	connBuilder.conn.logFunc = logFunc
 	return connBuilder
 }
 


### PR DESCRIPTION
### Description of the Change

Add a `logFunc` attribute in `Connection` to support for debug mode to log http request and response details when it's been assigned. The type of `logFunc` is `func(format string, v ...interface{})`, which is designed for flexibility and the most fit to plenty of existing logger implementations. So this makes it possible to bring your own logger to record the request/response informations. 

Only when this new attribute has been assigned, the debug mode will be enabled.

The most simple one is using the standard go log library `log.Printf` as the `logFunc`:

```go
conn, err := ovirtsdk4.NewConnectionBuilder().
    URL("engine-url").
    Username("admin@internal").
    Password("your-password").
    Insecure(true).
    LogFunc(log.Printf).
    Build()
```

After invoking `conn.SystemService().Get().MustSend().MustApi()`, `logFunc` may generate the following outputs:

```
2018/10/08 15:09:01 <<<<<<Request:
GET /ovirt-engine/api HTTP/1.1
Host: 10.1.110.70
User-Agent: GoSDK/4.3.0.a1
Accept: application/xml
Authorization: Bearer c-1ynrZcHwW-xvRUcZPV2O512SWk32quRJpbj07uIgTSkXXPGwEEgeNvJ1AX_n4SkFFRCGIShscbqgP_XYAjmQ
Content-Type: application/xml
Version: 4
Accept-Encoding: gzip

Response:
HTTP/1.1 200 OK
Connection: close
Content-Type: application/xml
Correlation-Id: 08b6d70d-05a3-4818-b805-77aeea2d3bbc
Date: Mon, 08 Oct 2018 07:09:01 GMT
Link: <https://10.1.110.70/ovirt-engine/api/affinitylabels>; rel=affinitylabels,<https://10.1.110.70/ovirt-engine/api/bookmarks>; rel=bookmarks,<https://10.1.110.70/ovirt-engine/api/clusterlevels>; rel=clusterlevels,<https://10.1.110.70/ovirt-engine/api/clusters>; rel=clusters,<https://10.1.110.70/ovirt-engine/api/clusters?search={query}>; rel=clusters/search,<https://10.1.110.70/ovirt-engine/api/cpuprofiles>; rel=cpuprofiles,<https://10.1.110.70/ovirt-engine/api/datacenters>; rel=datacenters,<https://10.1.110.70/ovirt-engine/api/datacenters?search={query}>; rel=datacenters/search,<https://10.1.110.70/ovirt-engine/api/diskprofiles>; rel=diskprofiles,<https://10.1.110.70/ovirt-engine/api/disks>; rel=disks,<https://10.1.110.70/ovirt-engine/api/disks?search={query}>; rel=disks/search,<https://10.1.110.70/ovirt-engine/api/domains>; rel=domains,<https://10.1.110.70/ovirt-engine/api/events;from={event_id}?search={query}>; rel=events/search,<https://10.1.110.70/ovirt-engine/api/events>; rel=events,<https://10.1.110.70/ovirt-engine/api/externalhostproviders>; rel=externalhostproviders,<https://10.1.110.70/ovirt-engine/api/externalvmimports>; rel=externalvmimports,<https://10.1.110.70/ovirt-engine/api/groups>; rel=groups,<https://10.1.110.70/ovirt-engine/api/groups?search={query}>; rel=groups/search,<https://10.1.110.70/ovirt-engine/api/hosts>; rel=hosts,<https://10.1.110.70/ovirt-engine/api/hosts?search={query}>; rel=hosts/search,<https://10.1.110.70/ovirt-engine/api/icons>; rel=icons,<https://10.1.110.70/ovirt-engine/api/imagetransfers>; rel=imagetransfers,<https://10.1.110.70/ovirt-engine/api/instancetypes>; rel=instancetypes,<https://10.1.110.70/ovirt-engine/api/instancetypes?search={query}>; rel=instancetypes/search,<https://10.1.110.70/ovirt-engine/api/jobs>; rel=jobs,<https://10.1.110.70/ovirt-engine/api/katelloerrata>; rel=katelloerrata,<https://10.1.110.70/ovirt-engine/api/macpools>; rel=macpools,<https://10.1.110.70/ovirt-engine/api/networkfilters>; rel=networkfilters,<https://10.1.110.70/ovirt-engine/api/networks>; rel=networks,<https://10.1.110.70/ovirt-engine/api/networks?search={query}>; rel=networks/search,<https://10.1.110.70/ovirt-engine/api/openstackimageproviders>; rel=openstackimageproviders,<https://10.1.110.70/ovirt-engine/api/openstacknetworkproviders>; rel=openstacknetworkproviders,<https://10.1.110.70/ovirt-engine/api/openstackvolumeproviders>; rel=openstackvolumeproviders,<https://10.1.110.70/ovirt-engine/api/operatingsystems>; rel=operatingsystems,<https://10.1.110.70/ovirt-engine/api/permissions>; rel=permissions,<https://10.1.110.70/ovirt-engine/api/roles>; rel=roles,<https://10.1.110.70/ovirt-engine/api/schedulingpolicies>; rel=schedulingpolicies,<https://10.1.110.70/ovirt-engine/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://10.1.110.70/ovirt-engine/api/storageconnections>; rel=storageconnections,<https://10.1.110.70/ovirt-engine/api/storagedomains>; rel=storagedomains,<https://10.1.110.70/ovirt-engine/api/storagedomains?search={query}>; rel=storagedomains/search,<https://10.1.110.70/ovirt-engine/api/tags>; rel=tags,<https://10.1.110.70/ovirt-engine/api/templates>; rel=templates,<https://10.1.110.70/ovirt-engine/api/templates?search={query}>; rel=templates/search,<https://10.1.110.70/ovirt-engine/api/users>; rel=users,<https://10.1.110.70/ovirt-engine/api/users?search={query}>; rel=users/search,<https://10.1.110.70/ovirt-engine/api/vmpools>; rel=vmpools,<https://10.1.110.70/ovirt-engine/api/vmpools?search={query}>; rel=vmpools/search,<https://10.1.110.70/ovirt-engine/api/vms>; rel=vms,<https://10.1.110.70/ovirt-engine/api/vms?search={query}>; rel=vms/search,<https://10.1.110.70/ovirt-engine/api/vnicprofiles>; rel=vnicprofiles
Server: Apache

<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<api>
    <link href="/ovirt-engine/api/clusters" rel="clusters"/>
    <link href="/ovirt-engine/api/clusters?search={query}" rel="clusters/search"/>
    <link href="/ovirt-engine/api/datacenters" rel="datacenters"/>
    <link href="/ovirt-engine/api/datacenters?search={query}" rel="datacenters/search"/>
    <link href="/ovirt-engine/api/events" rel="events"/>
    <link href="/ovirt-engine/api/events;from={event_id}?search={query}" rel="events/search"/>
    <link href="/ovirt-engine/api/hosts" rel="hosts"/>
    <link href="/ovirt-engine/api/hosts?search={query}" rel="hosts/search"/>
    <link href="/ovirt-engine/api/networks" rel="networks"/>
    <link href="/ovirt-engine/api/networks?search={query}" rel="networks/search"/>
    <link href="/ovirt-engine/api/roles" rel="roles"/>
    <link href="/ovirt-engine/api/storagedomains" rel="storagedomains"/>
    <link href="/ovirt-engine/api/storagedomains?search={query}" rel="storagedomains/search"/>
    <link href="/ovirt-engine/api/tags" rel="tags"/>
    <link href="/ovirt-engine/api/bookmarks" rel="bookmarks"/>
    <link href="/ovirt-engine/api/icons" rel="icons"/>
    <link href="/ovirt-engine/api/templates" rel="templates"/>
    <link href="/ovirt-engine/api/templates?search={query}" rel="templates/search"/>
    <link href="/ovirt-engine/api/instancetypes" rel="instancetypes"/>
    <link href="/ovirt-engine/api/instancetypes?search={query}" rel="instancetypes/search"/>
    <link href="/ovirt-engine/api/users" rel="users"/>
    <link href="/ovirt-engine/api/users?search={query}" rel="users/search"/>
    <link href="/ovirt-engine/api/groups" rel="groups"/>
    <link href="/ovirt-engine/api/groups?search={query}" rel="groups/search"/>
    <link href="/ovirt-engine/api/domains" rel="domains"/>
    <link href="/ovirt-engine/api/vmpools" rel="vmpools"/>
    <link href="/ovirt-engine/api/vmpools?search={query}" rel="vmpools/search"/>
    <link href="/ovirt-engine/api/vms" rel="vms"/>
    <link href="/ovirt-engine/api/vms?search={query}" rel="vms/search"/>
    <link href="/ovirt-engine/api/disks" rel="disks"/>
    <link href="/ovirt-engine/api/disks?search={query}" rel="disks/search"/>
    <link href="/ovirt-engine/api/jobs" rel="jobs"/>
    <link href="/ovirt-engine/api/storageconnections" rel="storageconnections"/>
    <link href="/ovirt-engine/api/vnicprofiles" rel="vnicprofiles"/>
    <link href="/ovirt-engine/api/diskprofiles" rel="diskprofiles"/>
    <link href="/ovirt-engine/api/cpuprofiles" rel="cpuprofiles"/>
    <link href="/ovirt-engine/api/schedulingpolicyunits" rel="schedulingpolicyunits"/>
    <link href="/ovirt-engine/api/schedulingpolicies" rel="schedulingpolicies"/>
    <link href="/ovirt-engine/api/permissions" rel="permissions"/>
    <link href="/ovirt-engine/api/macpools" rel="macpools"/>
    <link href="/ovirt-engine/api/networkfilters" rel="networkfilters"/>
    <link href="/ovirt-engine/api/operatingsystems" rel="operatingsystems"/>
    <link href="/ovirt-engine/api/externalhostproviders" rel="externalhostproviders"/>
    <link href="/ovirt-engine/api/openstackimageproviders" rel="openstackimageproviders"/>
    <link href="/ovirt-engine/api/openstackvolumeproviders" rel="openstackvolumeproviders"/>
    <link href="/ovirt-engine/api/openstacknetworkproviders" rel="openstacknetworkproviders"/>
    <link href="/ovirt-engine/api/katelloerrata" rel="katelloerrata"/>
    <link href="/ovirt-engine/api/affinitylabels" rel="affinitylabels"/>
    <link href="/ovirt-engine/api/clusterlevels" rel="clusterlevels"/>
    <link href="/ovirt-engine/api/imagetransfers" rel="imagetransfers"/>
    <link href="/ovirt-engine/api/externalvmimports" rel="externalvmimports"/>
    <product_info>
        <name>NeoKylin Virtualization Manager</name>
        <version>
            <build>9</build>
            <full_version>4.1.9.1-7.el7</full_version>
            <major>4</major>
            <minor>1</minor>
            <revision>0</revision>
        </version>
    </product_info>
    <special_objects>
        <blank_template href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
        <root_tag href="/ovirt-engine/api/tags/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000"/>
    </special_objects>
    <summary>
        <hosts>
            <active>3</active>
            <total>3</total>
        </hosts>
        <storage_domains>
            <active>4</active>
            <total>6</total>
        </storage_domains>
        <users>
            <active>1</active>
            <total>1</total>
        </users>
        <vms>
            <active>1</active>
            <total>3</total>
        </vms>
    </summary>
    <time>2018-10-08T15:09:01.633+08:00</time>
</api>
>>>>>>
```

### Applicable Issues

#129 .
