### PR TITLE
Prepare for release v4.0.5

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>go-sdk-parent</artifactId>
-    <version>4.3.0.a1-SNAPSHOT</version>
+    <version>4.0.5</version>
   </parent>
 
   <artifactId>go-sdk-generator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <groupId>org.ovirt.engine.api</groupId>
   <artifactId>go-sdk-parent</artifactId>
   <packaging>pom</packaging>
-  <version>4.3.0.a1-SNAPSHOT</version>
+  <version>4.0.5</version>
 
   <name>oVirt Go SDK Parent</name>
 
@@ -64,8 +64,8 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Version of the metamodel and model used to generate the SDK: -->
-    <metamodel.version>1.3.0</metamodel.version>
-    <model.version>4.3.7</model.version>
+    <metamodel.version>1.2.16</metamodel.version>
+    <model.version>4.2.37</model.version>
 
     <!-- The command used to start Go: -->
     <go.command>go</go.command>

--- a/sdk/ovirtsdk/version.go
+++ b/sdk/ovirtsdk/version.go
@@ -16,4 +16,4 @@
 package ovirtsdk
 
 // The version of the SDK:
-var SDK_VERSION = "4.3.0.a1"
+var SDK_VERSION = "4.0.5"

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>go-sdk-parent</artifactId>
-    <version>4.3.0.a1-SNAPSHOT</version>
+    <version>4.0.5</version>
   </parent>
 
   <artifactId>go-sdk</artifactId>


### PR DESCRIPTION
### Description of the Change

* Change version to 4.0.5 in three `pom.xml`
* Change version to 4.0.5 in `version.go` automatically
* Change `metamodel=1.2.16` and `model=4.2.37`, the same as used in latest official Python SDK release