### PR TITLE
Prepare for the release of 4.3.0

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>go-sdk-parent</artifactId>
-    <version>4.0.6</version>
+    <version>4.3.0</version>
   </parent>
 
   <artifactId>go-sdk-generator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <groupId>org.ovirt.engine.api</groupId>
   <artifactId>go-sdk-parent</artifactId>
   <packaging>pom</packaging>
-  <version>4.0.6</version>
+  <version>4.3.0</version>
 
   <name>oVirt Go SDK Parent</name>
 
@@ -64,8 +64,8 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Version of the metamodel and model used to generate the SDK: -->
-    <metamodel.version>1.2.16</metamodel.version>
-    <model.version>4.2.37</model.version>
+    <metamodel.version>1.3.0</metamodel.version>
+    <model.version>4.3.20</model.version>
 
     <!-- The command used to start Go: -->
     <go.command>go</go.command>

--- a/sdk/ovirtsdk/version.go
+++ b/sdk/ovirtsdk/version.go
@@ -16,4 +16,4 @@
 package ovirtsdk
 
 // The version of the SDK:
-var SDK_VERSION = "4.0.6"
+var SDK_VERSION = "4.3.0"

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>go-sdk-parent</artifactId>
-    <version>4.0.6</version>
+    <version>4.3.0</version>
   </parent>
 
   <artifactId>go-sdk</artifactId>


### PR DESCRIPTION
### Description of the Change

Do preparations for `4.3.0` release

* Update api.metamodel version to `1.3.0`
* Update api.model version to `4.3.20`

Signed-off-by: imjoey <majunjiev@gmail.com>