### PR TITLE
Prepare release 4.2.1

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>go-sdk-parent</artifactId>
-    <version>4.0.6</version>
+    <version>4.2.1</version>
   </parent>
 
   <artifactId>go-sdk-generator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <groupId>org.ovirt.engine.api</groupId>
   <artifactId>go-sdk-parent</artifactId>
   <packaging>pom</packaging>
-  <version>4.0.6</version>
+  <version>4.2.1</version>
 
   <name>oVirt Go SDK Parent</name>
 
@@ -55,7 +55,7 @@ limitations under the License.
     <connection>scm:git:git://gerrit.ovirt.org/ovirt-engine-sdk.git</connection>
     <developerConnection>scm:git:git://gerrit.ovirt.org/ovirt-engine-sdk.git</developerConnection>
     <url>git://gerrit.ovirt.org/ovirt-engine-sdk.git</url>
-    <tag>HEAD</tag>
+    <tag>4.2.1</tag>
   </scm>
 
   <properties>

--- a/sdk/CHANGES.adoc
+++ b/sdk/CHANGES.adoc
@@ -1,3 +1,9 @@
 = Changes
 
 This document describes the relevant changes between releases of the SDK.
+
+
+== 4.2.1 / Jan 16 2019
+
+This is considered to be the first stable release version in 4.2.x.
+In this release the model version is 4.2.37 and metamodel is 1.2.16.

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>go-sdk-parent</artifactId>
-    <version>4.0.6</version>
+    <version>4.2.1</version>
   </parent>
 
   <artifactId>go-sdk</artifactId>


### PR DESCRIPTION
### Description of the Change

After more than one year long development, the first stable version `4.2.1` will be released. This version is actually derived from `v4.0.6`. This pull request does the preparations for releasing:
* Update `CHANGES.adoc`
* Modify the version number
