### PR TITLE
Move to semantic versioning for stable releases

### DIFF
--- a/sdk/examples/add_affinity_label.go
+++ b/sdk/examples/add_affinity_label.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addAffinityLabel() {

--- a/sdk/examples/add_bond.go
+++ b/sdk/examples/add_bond.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addBond() {

--- a/sdk/examples/add_datacenter.go
+++ b/sdk/examples/add_datacenter.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addDatacenter() {

--- a/sdk/examples/add_disk.go
+++ b/sdk/examples/add_disk.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addDisk() {

--- a/sdk/examples/add_floating_disk.go
+++ b/sdk/examples/add_floating_disk.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addFloatingDisk() {

--- a/sdk/examples/add_group.go
+++ b/sdk/examples/add_group.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addGroup() {

--- a/sdk/examples/add_host.go
+++ b/sdk/examples/add_host.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addHost() {

--- a/sdk/examples/add_independent_vm.go
+++ b/sdk/examples/add_independent_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addIndependentVM() {

--- a/sdk/examples/add_instance_type.go
+++ b/sdk/examples/add_instance_type.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addInstanceType() {

--- a/sdk/examples/add_logical_network.go
+++ b/sdk/examples/add_logical_network.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addLogicalNetwork() {

--- a/sdk/examples/add_lun_disk_to_vm.go
+++ b/sdk/examples/add_lun_disk_to_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addLunDiskToVM() {

--- a/sdk/examples/add_mac_pool.go
+++ b/sdk/examples/add_mac_pool.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addMacPool() {

--- a/sdk/examples/add_nfs_data_storage_domain.go
+++ b/sdk/examples/add_nfs_data_storage_domain.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addNFSDataStorageDomain() {

--- a/sdk/examples/add_nfs_iso_storage_domain.go
+++ b/sdk/examples/add_nfs_iso_storage_domain.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addISODataStorageDomain() {

--- a/sdk/examples/add_tag.go
+++ b/sdk/examples/add_tag.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addTag() {

--- a/sdk/examples/add_template.go
+++ b/sdk/examples/add_template.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addTemplate() {

--- a/sdk/examples/add_user_public_sshkey.go
+++ b/sdk/examples/add_user_public_sshkey.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addUserPublicSSHKey() {

--- a/sdk/examples/add_vm.go
+++ b/sdk/examples/add_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addVM() {

--- a/sdk/examples/add_vm_disk.go
+++ b/sdk/examples/add_vm_disk.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addVMDisk() {

--- a/sdk/examples/add_vm_from_template.go
+++ b/sdk/examples/add_vm_from_template.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addVMFromTemplate() {

--- a/sdk/examples/add_vm_nic.go
+++ b/sdk/examples/add_vm_nic.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addVMNic() {

--- a/sdk/examples/add_vm_snapshot.go
+++ b/sdk/examples/add_vm_snapshot.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addVMSnapshot() {

--- a/sdk/examples/add_vm_with_sysprep.go
+++ b/sdk/examples/add_vm_with_sysprep.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addVMWithSysprep() {

--- a/sdk/examples/add_vnc_console.go
+++ b/sdk/examples/add_vnc_console.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func addVNCConsole() {

--- a/sdk/examples/assign_affinity_label_to_vm.go
+++ b/sdk/examples/assign_affinity_label_to_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func assignAffinityLabelToVM() {

--- a/sdk/examples/assign_network_to_cluster.go
+++ b/sdk/examples/assign_network_to_cluster.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func assignNetworkToCluster() {

--- a/sdk/examples/assign_tag_to_vm.go
+++ b/sdk/examples/assign_tag_to_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func assignTagToVM() {

--- a/sdk/examples/attach_nfs_data_storage_domain.go
+++ b/sdk/examples/attach_nfs_data_storage_domain.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func attachNFSDataStorageDomain() {

--- a/sdk/examples/attach_nfs_iso_storage_domain.go
+++ b/sdk/examples/attach_nfs_iso_storage_domain.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func attachISODataStorageDomain() {

--- a/sdk/examples/change_vm_cd.go
+++ b/sdk/examples/change_vm_cd.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func changeVMCd() {

--- a/sdk/examples/clone_vm_from_snapshot.go
+++ b/sdk/examples/clone_vm_from_snapshot.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func cloneVMFromSnapshot() {

--- a/sdk/examples/enable_serial_console.go
+++ b/sdk/examples/enable_serial_console.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func enableSerialConsole() {

--- a/sdk/examples/export_vm.go
+++ b/sdk/examples/export_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func exportVM() {

--- a/sdk/examples/follow_vm_links.go
+++ b/sdk/examples/follow_vm_links.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func followVMLinks() {

--- a/sdk/examples/import_glance_image.go
+++ b/sdk/examples/import_glance_image.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func importGlanceImage() {

--- a/sdk/examples/import_vm.go
+++ b/sdk/examples/import_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func importVM() {

--- a/sdk/examples/list_affinity_labels.go
+++ b/sdk/examples/list_affinity_labels.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func listAffinityLabels() {

--- a/sdk/examples/list_clusters.go
+++ b/sdk/examples/list_clusters.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func listClusters() {

--- a/sdk/examples/list_datacenters.go
+++ b/sdk/examples/list_datacenters.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func listDatacenters() {

--- a/sdk/examples/list_glance_images.go
+++ b/sdk/examples/list_glance_images.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func listGlanceImages() {

--- a/sdk/examples/list_hosts_statistics.go
+++ b/sdk/examples/list_hosts_statistics.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func listHostsStatistics() {

--- a/sdk/examples/list_operating_systems.go
+++ b/sdk/examples/list_operating_systems.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func listOperationSystem() {

--- a/sdk/examples/list_roles.go
+++ b/sdk/examples/list_roles.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func listRoles() {

--- a/sdk/examples/list_storage_domains.go
+++ b/sdk/examples/list_storage_domains.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func listStorageDomains() {

--- a/sdk/examples/list_vm_disks.go
+++ b/sdk/examples/list_vm_disks.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func listVMDisks() {

--- a/sdk/examples/list_vm_snapshots.go
+++ b/sdk/examples/list_vm_snapshots.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func listVMSnapshots() {

--- a/sdk/examples/list_vm_tags.go
+++ b/sdk/examples/list_vm_tags.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func listVMTags() {

--- a/sdk/examples/list_vms.go
+++ b/sdk/examples/list_vms.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func listVMs() {

--- a/sdk/examples/pin_vm.go
+++ b/sdk/examples/pin_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func pinVM() {

--- a/sdk/examples/process_errors.go
+++ b/sdk/examples/process_errors.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func processAuthError() {

--- a/sdk/examples/register_vm.go
+++ b/sdk/examples/register_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func registerVM() {

--- a/sdk/examples/remove_host.go
+++ b/sdk/examples/remove_host.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func removeHost() {

--- a/sdk/examples/remove_tag.go
+++ b/sdk/examples/remove_tag.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func removeTag() {

--- a/sdk/examples/remove_vm.go
+++ b/sdk/examples/remove_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func removeVM() {

--- a/sdk/examples/search_vms.go
+++ b/sdk/examples/search_vms.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func searchVM() {

--- a/sdk/examples/set_vm_lease_storage_domain.go
+++ b/sdk/examples/set_vm_lease_storage_domain.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func setVMLeaseStorageDomain() {

--- a/sdk/examples/start_vm.go
+++ b/sdk/examples/start_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func startVM() {

--- a/sdk/examples/start_vm_with_cloudinit.go
+++ b/sdk/examples/start_vm_with_cloudinit.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func startVMWithCloudinit() {

--- a/sdk/examples/stop_vm.go
+++ b/sdk/examples/stop_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func stopVM() {

--- a/sdk/examples/unassign_tag_to_vm.go
+++ b/sdk/examples/unassign_tag_to_vm.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func unassignTagToVM() {

--- a/sdk/examples/update_datacenter.go
+++ b/sdk/examples/update_datacenter.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func updateDatacenter() {

--- a/sdk/examples/update_fencing_options.go
+++ b/sdk/examples/update_fencing_options.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func updateFencingOptions() {

--- a/sdk/examples/update_quota_limits.go
+++ b/sdk/examples/update_quota_limits.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func updateQuotaLimits() {

--- a/sdk/examples/wait_vm_status.go
+++ b/sdk/examples/wait_vm_status.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+	ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 func waitVMStatus() {

--- a/sdk/ovirtsdk/README.md
+++ b/sdk/ovirtsdk/README.md
@@ -15,11 +15,12 @@ To use the SDK you should import ovirtsdk package as follows:
 
 ```go
 import (
-    ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4" // v4 <-> ovirt 4.x
+    ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 ```
 
-> __IMPORTANT__: In product environment, you should __NEVER__ use `import "github.com/imjoey/go-ovirt"` that it imports the master branch which will always be under heavy development.
+> __IMPORTANT__: To make it easy to manage dependencies on stable go-ovirt releases, starting with go-ovirt `4.2.2`, we will move to semantic versioning. If you are still using `v4.0.x` via importing `gopkg.in/imjoey/go-ovirt.v4` or `4.2.1`, we highly recommend you to update to `4.2.2` or above. In product environment, please __NEVER__ adopt the master branch which will always be under heavy development. 
+> 
 
 That will give you access to all the classes of the SDK, and in particular
 to the `Connection` class. This is the entry point of the SDK,
@@ -29,7 +30,7 @@ and gives you access to the root of the tree of services of the API:
 import (
     "fmt"
     "time"
-    ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+    ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 // Create the connection to the api server
@@ -64,7 +65,7 @@ Calling the regular functions is recommended, because it is  more accurate for c
 import (
     "fmt"
     "time"
-    ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+    ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 // Create the connection to the api server
@@ -115,7 +116,7 @@ if clusters, ok := clustersResponse.Clusters(); ok {
 import (
     "fmt"
     "time"
-    ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+    ovirtsdk4 "github.com/imjoey/go-ovirt"
 )
 
 // Create the connection to the api server


### PR DESCRIPTION
### Description of the Change

This project is on the moving to oVirt community with adding supporting for oVirt 4.2 and 4.3. So to make it easier to manage stable relases, we move to semantic versioning.

Changes proposed in this pull request:
* Add new guidance for semantic versioning usage
* Use `github.com/imjoey/go-ovirt` to import this sdk instead of `gopkg.in/imjoey/go-ovirt.v4` in examples codes

